### PR TITLE
Fixes spacing

### DIFF
--- a/src/components/Quote.tsx
+++ b/src/components/Quote.tsx
@@ -28,7 +28,6 @@ const QuoteContainer = styled.blockquote`
   }
 
   ::after {
-    content: '';
     display: none;
 
     @media ${query({ from: 'md' })} {

--- a/src/components/Quote.tsx
+++ b/src/components/Quote.tsx
@@ -29,9 +29,11 @@ const QuoteContainer = styled.blockquote`
 
   ::after {
     content: '';
+    display: none;
 
     @media ${query({ from: 'md' })} {
       content: '”';
+      display: inline-block;
     }
   }
 `

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -14,7 +14,7 @@ export const Section: React.FC = ({ children }) => {
         gapMd={64}
         paddingVertical={64}
         paddingVerticalMd={80}
-        paddingVerticalLg={148}
+        paddingVerticalLg={120}
         maxWidth="100%"
         marginHorizontal="auto"
       >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,7 +27,7 @@ const HomePage = () => (
     <Features />
     <Grid>
       <Box as="hr" margin={0} />
-      <Box paddingVertical={64} paddingVerticalMd={120}>
+      <Box paddingVertical={64} paddingVerticalLg={120}>
         <Quote
           name="Kent C. Dodds"
           title="Teacher, Google Developer Expert"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,7 +27,7 @@ const HomePage = () => (
     <Features />
     <Grid>
       <Box as="hr" margin={0} />
-      <Box paddingVertical={80} paddingVerticalMd={120}>
+      <Box paddingVertical={64} paddingVerticalMd={120}>
         <Quote
           name="Kent C. Dodds"
           title="Teacher, Google Developer Expert"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,7 +27,7 @@ const HomePage = () => (
     <Features />
     <Grid>
       <Box as="hr" margin={0} />
-      <Box paddingVertical={64} paddingVerticalLg={120}>
+      <Box paddingVertical={64} paddingVerticalMd={80} paddingVerticalLg={120}>
         <Quote
           name="Kent C. Dodds"
           title="Teacher, Google Developer Expert"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,7 +26,7 @@ const HomePage = () => (
     <Hero />
     <Features />
     <Grid>
-      <Box as="hr" marginBottom={0} />
+      <Box as="hr" margin={0} />
       <Box paddingVertical={80} paddingVerticalMd={120}>
         <Quote
           name="Kent C. Dodds"

--- a/src/sections/Features.tsx
+++ b/src/sections/Features.tsx
@@ -29,6 +29,7 @@ export const Features = () => {
         templateColsLg="repeat(3, 1fr)"
         gap={64}
         paddingVertical={64}
+        paddingVerticalMd={80}
         paddingVerticalLg={120}
       >
         <Section>

--- a/src/sections/Highlights.tsx
+++ b/src/sections/Highlights.tsx
@@ -21,7 +21,7 @@ const UnstyledUl = styled.ul`
 export const Highlights = () => {
   return (
     <Container>
-      <Grid paddingVertical={64} paddingVerticalMd={100}>
+      <Grid paddingVertical={64} paddingVerticalMd={80} paddingVerticalLg={120}>
         <Composition
           templateColsXl="repeat(2, 1fr)"
           alignItems="center"


### PR DESCRIPTION
## What?
in the Index component hr line has margin which was not needed.
in the Quote component spacing was bigger than in the other components.
In the mobile screen end quote was empty but did not hide.

## What I did?
Index component: deleted margin top.
in the Box around the Quote component fixes spacing to the 64px.
Quote: in the QuoteContainer made after quote `display: none` and from md screen `display: inline-block`