### PR TITLE
Updates jest.config.js to use setupFilesAfterEnv

### DIFF
--- a/docs/getting-started/integrate/node.mdx
+++ b/docs/getting-started/integrate/node.mdx
@@ -86,7 +86,7 @@ Open the `jest.setup.js` file and write there the same code as in the Create Rea
 ```js
 // jest.config.js
 module.exports = {
-  setupFiles: ['jest.setup.js'],
+  setupFilesAfterEnv: ['jest.setup.js'],
 }
 ```
 


### PR DESCRIPTION
Ensures that the test framework has been loaded and the before* and after* hooks are available.

When I run the code as in the example, I get an error: "ReferenceError: beforeAll is not defined". Switching the config entry from `setupFiles` to `setupFilesAfterEnv` fixed this issue for me.

It is possible that I was doing something wrong, and if so, please let me know! 