### PR TITLE
Updated install docs (install as dev dependency)

### DIFF
--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -12,9 +12,9 @@ Let's start by installing the `msw` package into our project.
 <Action>Run the following command in your project's root directory:</Action>
 
 ```bash
-$ npm install msw
+$ npm install msw --save-dev
 # or
-$ yarn add msw
+$ yarn add msw --dev
 ```
 
 ## Next step


### PR DESCRIPTION
### Motivation
Avoid people installing `msw` as a `dependency`, but instead it should be installed as a `devDependency` .
As the definition of dependency, it's something that will be bundled and shipped to the application code (but `msw` doesn't meet that requirement).

### Changes
- Updated install docs

