### PR TITLE
Docs: Adds "Binary response type" recipe

### DIFF
--- a/docs/recipes/binary-response-type.mdx
+++ b/docs/recipes/binary-response-type.mdx
@@ -1,0 +1,37 @@
+---
+title: Binary response type
+---
+
+Providing the `ctx.body()` utility function with a [`BufferSource`](https://developer.mozilla.org/en-US/docs/Web/API/BufferSource) object will use that buffer as the mocked response's body. Support of binary data allows to send any kind of media content (images, audio, documents) in a mocked response.
+
+## Example
+
+Here is an example of a mocked response that sends a local image:
+
+```js showLineNumbers focusedLines=6-9,12-15
+import { setupWorker, rest } from 'msw'
+import base64Image from 'url-loader!../fixtures/image.jpg'
+
+const worker = setupWorker(
+  rest.get('/images/:imageId', async (_, res, ctx) => {
+    // Convert "base64" image to "ArrayBuffer".
+    const imageBuffer = await fetch(base64Image).then((res) =>
+      res.arrayBuffer(),
+    )
+
+    return res(
+      ctx.set('Content-Length', imageBuffer.byteLength.toString()),
+      ctx.set('Content-Type', 'image/jpeg'),
+      // Respond with the "ArrayBuffer".
+      ctx.body(imageBuffer),
+    )
+  }),
+)
+
+worker.start()
+```
+
+<Hint>
+  Ensure that the <code>Content-Type</code> header of the response properly
+  describes your content.
+</Hint>


### PR DESCRIPTION
## Changes

- Adds a new "Binary response type" recipe to the documentation. That recipe illustrates how to respond with a local image.

## GitHub

- Documents https://github.com/mswjs/msw/issues/221 (https://github.com/mswjs/msw/pull/224)