### PR TITLE
Docs (Node): Mentions required absolute request URL for NodeJS

### DIFF
--- a/docs/getting-started/integrate/node.mdx
+++ b/docs/getting-started/integrate/node.mdx
@@ -103,3 +103,18 @@ test('allows user to log in', async () => {
   // Render components, perform requests, receive mocked responses.
 })
 ```
+
+## Direct usage
+
+You can use the `setupServer` API of Mock Service Worker in any NodeJS application (for example, when developing or testing an Express server).
+
+Bear in mind that without a DOM-like environment, like the jsdom from Jest, **you must use absolute request URLs in NodeJS**. This should be reflected in your request handlers:
+
+```js showLineNumbers focusedLines=2
+const server = setupServer(
+  // NOT "/user", nothing to be relative to!
+  rest.get('https://api.backend.dev/user', (req, res, ctx) => {
+    return res(ctx.json({ firstName: 'John' }))
+  }),
+)
+```


### PR DESCRIPTION
## Changes

- Mentions that for a direct usage in NodeJS (not as a part of any testing framework), one must always use absolute request URLs in request handlers.

## GitHub

- Surfaced from https://github.com/mswjs/msw/issues/263