### PR TITLE
Fix Gatsby and Next.js public directories

### DIFF
--- a/docs/snippets/public-dir.mdx
+++ b/docs/snippets/public-dir.mdx
@@ -9,8 +9,8 @@ Below you can find a list of public directories in most used JavaScript project 
 | Project name                                     | Public directory |
 | ------------------------------------------------ | ---------------- |
 | [Create React App](https://create-react-app.dev) | `./public`       |
-| [GatsbyJS](https://www.gatsbyjs.org)             | `./public`       |
-| [NextJS](https://nextjs.org)                     | `./static`       |
+| [GatsbyJS](https://www.gatsbyjs.org)             | `./static`       |
+| [NextJS](https://nextjs.org)                     | `./public`       |
 | [VueJS](https://vuejs.org/)                      | `./public`       |
 
 <Hint>


### PR DESCRIPTION
They were reversed.
see https://nextjs.org/docs/basic-features/static-file-serving and https://www.gatsbyjs.org/docs/static-folder/