### PR TITLE
Docs (Request): Removes deprecated "query", fixes "URL" type, adds "keepalive"

### DIFF
--- a/docs/api/request/index.mdx
+++ b/docs/api/request/index.mdx
@@ -33,7 +33,7 @@ Unlike a NodeJS `Request`, the request object in Mock Service Worker is a _parti
 | `referrerPolicy` | [`Request.referrerPolicy`](https://developer.mozilla.org/en-US/docs/Web/API/Request/referrerPolicy) |
 | `integrity`      | [`Request.integrity`](https://developer.mozilla.org/en-US/docs/Web/API/Request/integrity)           |
 | `destination`    | [`Request.destination`](https://developer.mozilla.org/en-US/docs/Web/API/Request/destination)       |
-
+| `keepalive`      | `boolean`                                                                                           |
 
 ### GraphQL
 

--- a/docs/api/request/index.mdx
+++ b/docs/api/request/index.mdx
@@ -19,8 +19,7 @@ Unlike a NodeJS `Request`, the request object in Mock Service Worker is a _parti
 
 | Property         | Type                                                                                                |
 | ---------------- | --------------------------------------------------------------------------------------------------- |
-| `url`            | `string`                                                                                            |
-| `query`          | [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)               |
+| `url`            | `URL`                                                                                               |
 | `body`           | `string`, `Record<string, any>`                                                                     |
 | `method`         | [`Request.method`](https://developer.mozilla.org/en-US/docs/Web/API/Request/method)                 |
 | `headers`        | [`Request.headers`](https://developer.mozilla.org/en-US/docs/Web/API/Request/headers)               |
@@ -34,6 +33,7 @@ Unlike a NodeJS `Request`, the request object in Mock Service Worker is a _parti
 | `referrerPolicy` | [`Request.referrerPolicy`](https://developer.mozilla.org/en-US/docs/Web/API/Request/referrerPolicy) |
 | `integrity`      | [`Request.integrity`](https://developer.mozilla.org/en-US/docs/Web/API/Request/integrity)           |
 | `destination`    | [`Request.destination`](https://developer.mozilla.org/en-US/docs/Web/API/Request/destination)       |
+
 
 ### GraphQL
 

--- a/docs/api/request/index.mdx
+++ b/docs/api/request/index.mdx
@@ -19,7 +19,7 @@ Unlike a NodeJS `Request`, the request object in Mock Service Worker is a _parti
 
 | Property         | Type                                                                                                |
 | ---------------- | --------------------------------------------------------------------------------------------------- |
-| `url`            | `URL`                                                                                               |
+| `url`            | [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)                                   |
 | `body`           | `string`, `Record<string, any>`                                                                     |
 | `method`         | [`Request.method`](https://developer.mozilla.org/en-US/docs/Web/API/Request/method)                 |
 | `headers`        | [`Request.headers`](https://developer.mozilla.org/en-US/docs/Web/API/Request/headers)               |


### PR DESCRIPTION
@kettanaito 

I noticed the _query_ ppty was absent from the ts types.

I found a thread where you say it's been deprecated but found it in the docs

don't know if this is valid and if so if you want to phrase it like that (or no at all ;)

thanks