### PR TITLE
Wrong file name, it should be "browser.js"

### DIFF
--- a/docs/getting-started/integrate/browser.mdx
+++ b/docs/getting-started/integrate/browser.mdx
@@ -62,7 +62,7 @@ In order for our mock definition to excute during the runtime, it needs to be im
   production. Doing so may lead to a distorted experience for your users.
 </Hint>
 <Action>
-  Import the <code>mocks.js</code> file conditionally following one of the
+  Import the <code>browser.js</code> file conditionally following one of the
   examples below:
 </Action>
 

--- a/docs/getting-started/integrate/browser.mdx
+++ b/docs/getting-started/integrate/browser.mdx
@@ -62,7 +62,7 @@ In order for our mock definition to excute during the runtime, it needs to be im
   production. Doing so may lead to a distorted experience for your users.
 </Hint>
 <Action>
-  Import the <code>browser.js</code> file conditionally following one of the
+  Import the <code>src/mocks/browser.js</code> file conditionally following one of the
   examples below:
 </Action>
 


### PR DESCRIPTION
In the documentation, there is a line which says:
"Import the `mocks.js` file conditionally following one of the examples below"

But `mocks.js` is never defined in the whole document page, and it supposed to be `browser.js` but wrongly addressed a different file (which did not exist)