### PR TITLE
Docs (API: graphql): Adds "graphql.link" API

### DIFF
--- a/docs/api/graphql/index.mdx
+++ b/docs/api/graphql/index.mdx
@@ -7,7 +7,7 @@ The `graphql` namespace contains a set of [Request handlers](/docs/basics/reques
 
 ## Methods
 
-Each method in this namespace represents a GraphQL operation kind:
+Methods of this namespace represent GraphQL operation kinds:
 
 - `graphql.query()`
 - `graphql.mutation()`
@@ -75,6 +75,20 @@ const worker = setupWorker(
 
 worker.start()
 ```
+
+### Multiple GraphQL endpoints
+
+When your application communicates with multiple GraphQL endpoints it's useful to establish a per-endpoint requests interception.
+
+Please refer to the following `graphql.link` API:
+
+import * as GraphQLLinkAPI from './link.mdx'
+
+<PageLink
+  title="graphql.link()"
+  page={GraphQLLinkAPI}
+  url="/docs/api/graphql/link"
+/>
 
 ### Usage with TypeScript
 

--- a/docs/api/graphql/link.mdx
+++ b/docs/api/graphql/link.mdx
@@ -1,0 +1,36 @@
+---
+title: link()
+---
+
+Helper function that created endpoint-based GraphQL operations interception.
+
+`graphql.link()` is primarily designed for applications that communicate with multiple GraphQL endpoints to prevent operation name collision during API mocking.
+
+## Call signature
+
+```ts
+function link(uri: string): GraphQLMethods
+```
+
+## Examples
+
+```js showLineNumbers focusedLines=3-4,7-8
+import { setupWorker, graphql } from 'msw'
+
+const github = graphql.link('https://api.github.com/graphql')
+const stripe = graphql.link('https://api.stripe.com/graphql')
+
+const worker = setupWorker(
+  github.query('GetUser', resolveGitHubUser),
+  stripe.mutation('Payment', resolveStripePayment),
+
+  // Although this operation name is `GetUser`,
+  // it will get captured only when the request is issued
+  // against the current location (no link specified).
+  graphql.query('GetUser', (req, res, ctx) => {
+    return res()
+  }),
+)
+
+worker.start()
+```


### PR DESCRIPTION
## Changes

- Adds `graphql.link()` API to the docs.

## GitHub

- Documents https://github.com/mswjs/msw/pull/319