### PR TITLE
Fix "Reusable resolver" code to be valid JS

### DIFF
--- a/docs/basics/response-resolver.mdx
+++ b/docs/basics/response-resolver.mdx
@@ -66,7 +66,7 @@ import { setupWorker, rest } from 'msw'
 import { mockUser } from './resolvers/mockUser'
 
 const worker = setupWorker(
-  rest.get('/user', mockUser)
+  rest.get('/user', mockUser),
   rest.get('/me', mockUser)
 )
 


### PR DESCRIPTION
A required comma between function arguments was missing.