### PR TITLE
docs: add angular public

### DIFF
--- a/docs/snippets/public-dir.mdx
+++ b/docs/snippets/public-dir.mdx
@@ -6,12 +6,13 @@ A public directory is usually a root directory of your server (i.e. `./build`, `
 
 Below you can find a list of public directories in most used JavaScript project starters.
 
-| Project name                                     | Public directory |
-| ------------------------------------------------ | ---------------- |
-| [Create React App](https://create-react-app.dev) | `./public`       |
-| [GatsbyJS](https://www.gatsbyjs.org)             | `./static`       |
-| [NextJS](https://nextjs.org)                     | `./public`       |
-| [VueJS](https://vuejs.org/)                      | `./public`       |
+| Project name                                     | Public directory                                                |
+| ------------------------------------------------ | --------------------------------------------------------------- |
+| [Create React App](https://create-react-app.dev) | `./public`                                                      |
+| [GatsbyJS](https://www.gatsbyjs.org)             | `./static`                                                      |
+| [NextJS](https://nextjs.org)                     | `./public`                                                      |
+| [VueJS](https://vuejs.org/)                      | `./public`                                                      |
+| [Angular](https://angular.io/)                   | `./src` (and add it to the `assets` of the `angular.json` file) |
 
 <Hint>
   Not sure where is your public directory? Reach out to the maintainers of the


### PR DESCRIPTION
I'm not entirely sure if this is the best way to put it.
Do you think this is fine, or what could be improved?

For more info:

The public folder for an angular application is actually `./src/assets`. If a file is added to that directory, it well get served automatically. The "problem" is that the default behavior of MSW expects the `mockServerWorker.js` to be available under `/mockServerWorker.js`. If we put that file inside the assets, it's available under `/assets/mockServerWorker.js`. This would mean that we don't have to make a change to the angular compile step, but rather a change to the setup of MSW.

In the angular settings you can add more files (or directories) to be included in the public folder. This is the way that I'm currently using, and this is also how this is documented within this PR. We add the `mockServerWorker.js` file to the `src` folder, and change the angular settings to "make" that file public. 