### PR TITLE
docs: fix typo Sercive -> Service

### DIFF
--- a/src/sections/Integration.tsx
+++ b/src/sections/Integration.tsx
@@ -50,7 +50,7 @@ export const Integration = () => {
         <Text color="gray">
           API mocking that is available anywhere: during development, on any
           level of testing, and even debugging. Living in a dedicated layer,
-          Mock Sercive Worker is agnostic of the frameworks, libraries, or
+          Mock Service Worker is agnostic of the frameworks, libraries, or
           setups you may use.
         </Text>
         <ReadmoreLink href="https://github.com/mswjs/examples">


### PR DESCRIPTION
Just a small typo in the integration section 🙂

Thank you!