### PR TITLE
Docs (delay): Elaborates on the "realistic" response time

### DIFF
--- a/docs/api/context/delay.mdx
+++ b/docs/api/context/delay.mdx
@@ -5,6 +5,8 @@ order: 579
 
 Delays the response by the given duration (in ms). When no duration is provided, uses a random realistic server response time.
 
+> Realistic response time is a random duration based on the average response time of a real server, considering a good connection.
+
 ## Call signature
 
 ```ts


### PR DESCRIPTION
Prevents confusion over what the "realistic" term refers on that page.