### PR TITLE
Upgrade node-match-path to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gatsby-plugin-typescript": "^2.3.1",
     "gatsby-source-filesystem": "^2.2.2",
     "gatsby-transformer-sharp": "^2.4.3",
-    "node-match-path": "^0.4.2",
+    "node-match-path": "^0.5.1",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-cdx": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10845,10 +10845,10 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-match-path@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.4.2.tgz#30cc39510fa493bff03c3d0d2fff711c868ec457"
-  integrity sha512-wfde4FOC5A8RTSUVZ7pTpBV+dJsr2vVxT6374VrNam6wnnhx6EvwAwL/E/r3AW/YU6XkeZggF5xfBlu4a/ULBg==
+node-match-path@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.5.1.tgz#65d2fadef8bbded238cb89918de0c6c3c758aa22"
+  integrity sha512-C1IHXMxhKglNiCMxHmYrknLX6CUARvs9SdsnZ+3rdMvH8wJIX/pRq4KzThvEz4LNyiU+KrSP7GH1EsdwWYNl3g==
 
 node-object-hash@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR upgrades node-match-path so the path match tool at the website will support underscores in path parameters.