### PR TITLE
docs: add Preact CLI's public directory

### DIFF
--- a/docs/snippets/public-dir.mdx
+++ b/docs/snippets/public-dir.mdx
@@ -13,7 +13,7 @@ Below you can find a list of public directories in most used JavaScript project 
 | [NextJS](https://nextjs.org)                     | `./public`                                                      |
 | [VueJS](https://vuejs.org/)                      | `./public`                                                      |
 | [Angular](https://angular.io/)                   | `./src` (and add it to the `assets` of the `angular.json` file) |
-| [Preact CLI](https://preactjs.com/cli)           | `./src/static`                                                  |
+| [Preact](https://preactjs.com)                   | `./src/static`                                                  |
 
 <Hint>
   Not sure where is your public directory? Reach out to the maintainers of the

--- a/docs/snippets/public-dir.mdx
+++ b/docs/snippets/public-dir.mdx
@@ -13,6 +13,7 @@ Below you can find a list of public directories in most used JavaScript project 
 | [NextJS](https://nextjs.org)                     | `./public`                                                      |
 | [VueJS](https://vuejs.org/)                      | `./public`                                                      |
 | [Angular](https://angular.io/)                   | `./src` (and add it to the `assets` of the `angular.json` file) |
+| [Preact CLI](https://preactjs.com/cli)           | `./src/static`                                                  |
 
 <Hint>
   Not sure where is your public directory? Reach out to the maintainers of the


### PR DESCRIPTION
Hi, I'm enjoying MSW in several React projects, and now I'm playing with Preact.

In projects created with [Preact CLI](https://preactjs.com/cli), any files in `src/static/` will be copied to `build/` directory.

https://github.com/preactjs/preact-cli/blob/v3.0.3/packages/cli/lib/lib/webpack/webpack-client-config.js#L99-L103