### PR TITLE
docs: Add warning about __typename

### DIFF
--- a/docs/api/graphql/query.mdx
+++ b/docs/api/graphql/query.mdx
@@ -14,6 +14,10 @@ A request handler that captures a GraphQL query by the given name.
   for the endpoint-based mocking.
 </Hint>
 
+<Hint mode="warning">
+  If you’re using Apollo Client, you may have to add `__typename`s to mock responses.
+</Hint>
+
 ## Call signature
 
 ```ts

--- a/docs/api/graphql/query.mdx
+++ b/docs/api/graphql/query.mdx
@@ -14,10 +14,6 @@ A request handler that captures a GraphQL query by the given name.
   for the endpoint-based mocking.
 </Hint>
 
-<Hint mode="warning">
-  If you’re using Apollo Client, you may have to add `__typename`s to mock responses.
-</Hint>
-
 ## Call signature
 
 ```ts

--- a/docs/getting-started/mocks/graphql-api.mdx
+++ b/docs/getting-started/mocks/graphql-api.mdx
@@ -155,6 +155,31 @@ export const handlers = [
 
 > Utilize things like [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage), [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), or [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) to handle more complex API scenarios and user interactions.
 
+<Hint mode="warning">
+  <p>
+    Some GraphQL clients (i.e.{' '}
+    <a href="https://www.apollographql.com/docs/">Apollo</a>) may require you to
+    include the <code>__typename</code> property on each individual type on the
+    mocked response:
+  </p>
+  <code
+    className="language-javascript"
+    children={`
+ctx.data({
+  user: {
+    firstName: 'John',
+    lastName: 'Maverick',
+    __typename: 'User'
+  }
+})
+  `}
+  />
+  <p>
+    Follow the response shape of your GraphQL client to ensure you produce a
+    compatible mocked response.
+  </p>
+</Hint>
+
 ## Next step
 
 The request handlers are complete, yet there is one last step to perform: integrate the mocking.


### PR DESCRIPTION
Not sure what’s the actual problem (Apollo?) but probably worth documenting: I had undefined `data` without any errors until I added `__typename` everywhere.

![image](https://user-images.githubusercontent.com/70067/96996832-d91b7180-1530-11eb-8fd3-c33fecb609dc.png)
