### PR TITLE
Docs: update link to Request matching

### DIFF
--- a/docs/basics/request-handler.mdx
+++ b/docs/basics/request-handler.mdx
@@ -30,5 +30,5 @@ Request handlers are responsible for requests matching—a process of deciding w
 
 <Hint>
   Read more about which requests are being mocked in{' '}
-  <a href="/docs/basics/path-matching">Path matching</a>.
+  <a href="/docs/basics/request-matching">Request matching</a>.
 </Hint>


### PR DESCRIPTION
update link from `Path matching` to `Request matching`