### PR TITLE
docs: just a small small typo, hases => hashes

### DIFF
--- a/docs/basics/request-matching.mdx
+++ b/docs/basics/request-matching.mdx
@@ -20,7 +20,7 @@ Working with `rest.*` request handlers allows you to match requests by the follo
 - Request URL.
 
 <Hint mode="warning">
-  Query parameters and hases are removed from the URL during matching.
+  Query parameters and hashes are removed from the URL during matching.
 </Hint>
 
 ### Request method


### PR DESCRIPTION
See title, just a single character change