### PR TITLE
docs: Update broken link for ctx

### DIFF
--- a/docs/basics/response-transformer.mdx
+++ b/docs/basics/response-transformer.mdx
@@ -42,7 +42,7 @@ Of course, setting a fixed status code is rarely what you want. To parametrize t
 
 ## Standards transformers
 
-Please see the list of standard response transformers available in the [`ctx`](/docs/basics/response-resolver/context#standard-context) argument of a response resolver.
+Please see the list of standard response transformers available in the [`ctx`](/docs/api/context) argument of a response resolver.
 
 <Hint mode="varning">
   Some response transformers are specific to the type of the API you are mocking


### PR DESCRIPTION
The current link for ctx, https://mswjs.io/docs/basics/response-resolver/context#standard-context, returns a 404. This PR replaces it with the actual context page.