### PR TITLE
fix(response patching): convert readableStream to JSON

### DIFF
--- a/docs/recipes/response-patching.mdx
+++ b/docs/recipes/response-patching.mdx
@@ -18,10 +18,11 @@ const worker = setupWorker(
   rest.get('https://api.github.com/users/:username', async (req, res, ctx) => {
     // Perform an original request to the intercepted request URL
     const originalResponse = await ctx.fetch(req)
+    const originalResponseData = await originalResponse.json()
 
     return res(
       ctx.json({
-        location: originalResponse.location,
+        location: originalResponseData.location,
         firstName: 'Not the real first name',
       }),
     )


### PR DESCRIPTION
mention having to await the response to be converted from readableStream to JSON before being able to use it in the MSW mocked response