### PR TITLE
docs: Add cache reset example for Apollo Client

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -96,4 +96,14 @@ beforeEach(() => {
 })
 ```
 
+### Apollo Client 
+
+```js
+import { client } from '../lib/apolloClient';
+
+beforeEach(() => {
+  return client.cache.reset()
+})
+```
+
 > The exact API for clearing cache may differ depending on your request client. Please refer to your request client's documentation for more details.


### PR DESCRIPTION
As we started migration from the Apollo `MockedProvider` to MSW, one issue we ran into was the Apollo Client caching query results between tests. This is the solution that worked best for us, but I'm open to discuss alternatives.

Thanks for all of your incredible work on MSW! Our test suites (and engineers) are much happier after our migration.