### PR TITLE
Fix typo "propery" in query-parameters page

### DIFF
--- a/docs/recipes/query-parameters.mdx
+++ b/docs/recipes/query-parameters.mdx
@@ -3,7 +3,7 @@ title: Query parameters
 order: 72
 ---
 
-In order to access a query parameter of the intercepted request, use the `searchParams` propery on the `req.url` instance. The value of that property is a [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) instance that contains all query parameters.
+In order to access a query parameter of the intercepted request, use the `searchParams` property on the `req.url` instance. The value of that property is a [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) instance that contains all query parameters.
 
 ## Examples
 


### PR DESCRIPTION
As title, replace the typo "propery" with "property" in query-parameter page.
See #113 