### PR TITLE
Update relative path for jest.setup.js file

### DIFF
--- a/docs/getting-started/integrate/node.mdx
+++ b/docs/getting-started/integrate/node.mdx
@@ -85,7 +85,7 @@ Open the `jest.setup.js` file and write there the same code as in the Create Rea
 ```js
 // jest.config.js
 module.exports = {
-  setupFilesAfterEnv: ['jest.setup.js'],
+  setupFilesAfterEnv: ['./jest.setup.js'],
 }
 ```
 


### PR DESCRIPTION
As the documentation says, it's better to use a relative path to reference `jest.setup.js` file.
Otherwise, it often cannot be found.
ref: https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array