### PR TITLE
Update CDN example

### DIFF
--- a/docs/recipes/usage-with-cdn.mdx
+++ b/docs/recipes/usage-with-cdn.mdx
@@ -8,13 +8,13 @@ Pick a suitable CDN that can serve NPM modules and include the respective script
 ### unpkg
 
 ```html
-<script src="https://unpkg.com/msw/lib/index.js"></script>
+<script src="https://unpkg.com/msw/lib/iife/index.js"></script>
 ```
 
 ### jsDelivr
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/msw/lib/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/msw/lib/iife/index.js"></script>
 ```
 
 ## Place the Service Worker


### PR DESCRIPTION
With the release of msw 0.25.0 and the availability of an iife bundle, executing msw from a CDN works! 
This is an update to the documentation to reflect the change.