### PR TITLE
Fix Life-cycle events documentation variable name

### DIFF
--- a/docs/extensions/life-cycle-events/index.mdx
+++ b/docs/extensions/life-cycle-events/index.mdx
@@ -56,6 +56,6 @@ worker.on('request:start', (req) => {
 
 worker.on('response:mocked', (res, reqId) => {
   // Get a request associated with this response.
-  const req = requests.get(reqId)
+  const req = allRequests.get(reqId)
 })
 ```


### PR DESCRIPTION
The `Map` variable name in the `Tracking a request` documentation section is inconsistent and misleading