### PR TITLE
docs(rest-api): fix ts error

### DIFF
--- a/docs/getting-started/mocks/rest-api.mdx
+++ b/docs/getting-started/mocks/rest-api.mdx
@@ -64,7 +64,7 @@ import { rest } from 'msw'
 export const handlers = [
   rest.post('/login', (req, res, ctx) => {
     // Persist user's authentication in the session
-    sessionStorage.setItem('is-authenticated', true)
+    sessionStorage.setItem('is-authenticated', 'true')
 
     return res(
       // Respond with a 200 status code


### PR DESCRIPTION
This example has a TS error. I fixed it.

![error](https://user-images.githubusercontent.com/28596482/110326333-e195c400-805b-11eb-8553-edd304b8a441.png)
> Argument of type 'boolean' is not assignable to parameter of type 'string'.ts(2345)

