### PR TITLE
docs: add default response status value

### DIFF
--- a/docs/api/response/index.mdx
+++ b/docs/api/response/index.mdx
@@ -15,7 +15,7 @@ A call to the `res()` function creates a mocked response object. Each response t
 
 | Property name | Type                                                                          | Description                                                   |
 | ------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `status`      | `number`                                                                      | Mocked response HTTP status code. (_Default:_ `200`)              |
+| `status`      | `number`                                                                      | Mocked response HTTP status code. (_Default:_ `200`)          |
 | `statusText`  | `string`                                                                      | HTTP status text of the current status code.                  |
 | `body`        | `string`                                                                      | Stringified body of the response.                             |
 | `headers`     | [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/Headers) | Mocked response HTTP headers.                                 |

--- a/docs/api/response/index.mdx
+++ b/docs/api/response/index.mdx
@@ -15,7 +15,7 @@ A call to the `res()` function creates a mocked response object. Each response t
 
 | Property name | Type                                                                          | Description                                                   |
 | ------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `status`      | `number`                                                                      | Mocked response HTTP status code.                             |
+| `status`      | `number`                                                                      | Mocked response HTTP status code. Default is 200              |
 | `statusText`  | `string`                                                                      | HTTP status text of the current status code.                  |
 | `body`        | `string`                                                                      | Stringified body of the response.                             |
 | `headers`     | [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/Headers) | Mocked response HTTP headers.                                 |

--- a/docs/api/response/index.mdx
+++ b/docs/api/response/index.mdx
@@ -15,7 +15,7 @@ A call to the `res()` function creates a mocked response object. Each response t
 
 | Property name | Type                                                                          | Description                                                   |
 | ------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `status`      | `number`                                                                      | Mocked response HTTP status code. Default is 200              |
+| `status`      | `number`                                                                      | Mocked response HTTP status code. (_Default:_ `200`)              |
 | `statusText`  | `string`                                                                      | HTTP status text of the current status code.                  |
 | `body`        | `string`                                                                      | Stringified body of the response.                             |
 | `headers`     | [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/Headers) | Mocked response HTTP headers.                                 |


### PR DESCRIPTION
While using msw, I noticed that `res(ctx.status(200))` does not have to be passed explicitly, instead if no `ctx.status()` is provided, it defaults to 200. 

When I was first starting out, I wasn't sure if 200 indeed was the default, so I tried looking it up in the docs and I couldn't find it.

If 200 indeed is the default `ctx.status()` value, then I think, it would be helpful if it was clearly outlined somewhere in the docs