### PR TITLE
Update example to await worker.start()

### DIFF
--- a/docs/getting-started/integrate/browser.mdx
+++ b/docs/getting-started/integrate/browser.mdx
@@ -74,12 +74,16 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
 
-if (process.env.NODE_ENV === 'development') {
-  const { worker } = require('./mocks/browser')
-  worker.start()
+async function main() {
+  if (process.env.NODE_ENV === 'development') {
+    const { worker } = require('./mocks/browser')
+    await worker.start()
+  }
+
+  ReactDOM.render(<App />, document.getElementById('root'))
 }
 
-ReactDOM.render(<App />, document.getElementById('root'))
+main()
 ```
 
 ## Verify & Inspect


### PR DESCRIPTION
Update the docs to make it clear that `worker.start` is an async function that should be awaited before the call to `ReactDOM.render`, or any immediately made requests may not be mocked.

Spent a little while bashing my head against a brick wall the other day trying to figure out why `msw` was starting, but not mocking the first request my app makes: fetching details of the currently logged in user. Was only when I happened to see an example for an unrelated problem that happened to wrap the call to `worker.start()` in an async function that I had a facepalm moment and realised. Brain was clearly not on top form that day. Hopefully this will save some future users that confusion.	