### PR TITLE
Update listen.mdx

### DIFF
--- a/docs/api/setup-server/listen.mdx
+++ b/docs/api/setup-server/listen.mdx
@@ -16,11 +16,14 @@ Specifies how to handle a request that is not listed in the request handlers.
 
 #### Pre-defined behaviors
 
+With these options, the unhandled request gets performed and a message is logged. If you want to prevent the request altogether, you can use a custom callback.
+
 | Option name | Description                                            |
 | ----------- | ------------------------------------------------------ |
-| `"bypass"`  | Performs an unhandled request as-is.                   |
+| `"bypass"`  | Does not print anything.                   |
 | `"warn"`    | Prints a warning into `stdout` of the current process. |
 | `"error"`   | Prints an error into `stderr` of the current process.  |
+
 
 ```js showLineNumbers focusedLines=8
 const server = setupServer(


### PR DESCRIPTION
The description of `"bypass"` somewhat misleads you to believe that `"warn"` and `"error"` don't perform the unhandled request, because the description differs from the one option, where it is specifically mentioned.

At first I wished that
`"bypass"` - performs request as is
`"warn"` - performs request as is and prints a warning
`"bypass"` - prevents the request and prints an error