### PR TITLE
Fix link from setup-server to setup-worker

### DIFF
--- a/docs/api/setup-server/index.mdx
+++ b/docs/api/setup-server/index.mdx
@@ -8,7 +8,7 @@ A function that sets up a request interception layer in NodeJS environment.
 <Hint>
   This function is designed for NodeJS environoment. If looking for a way to
   apply API mocking in a browser environment, consider using{' '}
-  <a href="/sdg">
+  <a href="/docs/api/setup-worker">
     <code>setupWorker</code>
   </a>{' '}
   instead.


### PR DESCRIPTION
The link to `setupWorker` on the `setupServer` page was broken.