### PR TITLE
'Content-Length' value should be a string

### DIFF
--- a/docs/api/context/set.mdx
+++ b/docs/api/context/set.mdx
@@ -42,7 +42,7 @@ rest.get('/user', (req, res, ctx) => {
     ctx.set({
       'Accept-Language': 'en-US',
       'Content-Type': ['applcation/json', 'application/hal+json'],
-      'Content-Length': 40032,
+      'Content-Length': '40032',
     }),
   )
 })


### PR DESCRIPTION
When setting 'Content-Length' header as a number, you get an error using Typescript. Header value should be a strings or array of strings.

Argument of type '[{ 'Content-Type': string; 'Content-Length': number; }]' is not assignable to parameter of type '[string, string] | [Record<string, string | string[]>]'.
  Type '[{ 'Content-Type': string; 'Content-Length': number; }]' is not assignable to type '[Record<string, string | string[]>]'.
    Type '{ 'Content-Type': string; 'Content-Length': number; }' is not assignable to type 'Record<string, string | string[]>'.
      Property ''Content-Length'' is incompatible with index signature.
        Type 'number' is not assignable to type 'string | string[]'.ts(2345)