### PR TITLE
jest.config.js - add note of location in root dir

### DIFF
--- a/docs/getting-started/integrate/node.mdx
+++ b/docs/getting-started/integrate/node.mdx
@@ -89,7 +89,7 @@ module.exports = {
 }
 ```
 
-> Create `jest.config.js`, if you don't have it already.
+> Create `jest.config.js`, if you don't have it already. Make sure that jest.config.js is created in the root directory of your project.
 
 ## Run tests
 


### PR DESCRIPTION
Hello,

When setting up a custom project (instead of create react app), I ran into an issue where the jest.config.js file was not being read by the compiler. I solved it by moving it to the root directory (instead of the __tests__ file). I realize that this may be an innocuous change for something that should be obvious, but I struggled mightily with this issue for days when trying to set up MSW. I thought the small note about this on line 92 would be helpful for others new to testing, especially with jest and MSW. When I made t

Thanks,

David