### PR TITLE
Convert req.url to string before passing to `matchRequestUrl`

### DIFF
--- a/docs/extensions/life-cycle-events/index.mdx
+++ b/docs/extensions/life-cycle-events/index.mdx
@@ -237,7 +237,7 @@ function waitForRequest(method: string, url: string) {
   return new Promise((resolve, reject) => {
     server.events.on('request:start', (req) => {
       const matchesMethod = req.method.toLowerCase() === method.toLowerCase()
-      const matchesUrl = matchRequestUrl(url, req.url)
+      const matchesUrl = matchRequestUrl(req.url, url)
 
       if (matchesMethod && matchRequestUrl) {
         requestId = req.id

--- a/docs/extensions/life-cycle-events/index.mdx
+++ b/docs/extensions/life-cycle-events/index.mdx
@@ -239,7 +239,7 @@ function waitForRequest(method: string, url: string) {
       const matchesMethod = req.method.toLowerCase() === method.toLowerCase()
       const matchesUrl = matchRequestUrl(req.url, url)
 
-      if (matchesMethod && matchRequestUrl) {
+      if (matchesMethod && matchesUrl) {
         requestId = req.id
       }
     })


### PR DESCRIPTION
`req.url` looks like it's a url object, but if we pass a url object it ends up failing here:

https://github.com/mswjs/msw/blob/87972dcf24783fb1988b4944b2489ab8194a3e29/src/utils/url/getAbsoluteUrl.ts#L6