### PR TITLE
docs: Leading Dollar Sign

### DIFF
--- a/docs/cli/init.mdx
+++ b/docs/cli/init.mdx
@@ -8,7 +8,7 @@ Places the Service Worker file into a given public directory of your application
 ## Usage
 
 ```bash
-$ npx msw init <PUBLIC_DIR> [options]
+npx msw init <PUBLIC_DIR> [options]
 ```
 
 ### Arguments
@@ -18,7 +18,7 @@ $ npx msw init <PUBLIC_DIR> [options]
 A relative path to the public directory of your application.
 
 ```bash
-$ npx msw init ./public
+npx msw init ./public
 ```
 
 ### Options
@@ -28,7 +28,7 @@ $ npx msw init ./public
 Save the given `PUBLIC_DIR` in your package.json for future use.
 
 ```bash
-$ npx msw init ./public --save
+npx msw init ./public --save
 ```
 
 Your public directory will be saved in package.json under the `msw.workerDirectory` path:

--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -12,9 +12,9 @@ Let's start by installing the `msw` package into our project.
 <Action>Run the following command in your project's root directory:</Action>
 
 ```bash
-$ npm install msw --save-dev
+npm install msw --save-dev
 # or
-$ yarn add msw --dev
+yarn add msw --dev
 ```
 
 ## Next step

--- a/docs/getting-started/integrate/browser.mdx
+++ b/docs/getting-started/integrate/browser.mdx
@@ -12,13 +12,13 @@ Mock Service Worker operates client-side by registering a [Service Worker](https
 </Action>
 
 ```bash
-$ npx msw init <PUBLIC_DIR> --save
+npx msw init <PUBLIC_DIR> --save
 ```
 
 Replace the `<PUBLIC_DIR>` placeholder with the relative path to your server's public directory. For example, in a Create React App project this command would be:
 
 ```bash
-$ npx msw init public/ --save
+npx msw init public/ --save
 ```
 
 > Note that we are using the `--save` option to save the given worker directory ("public") in the package.json. That way any updates to the worker script will be automatically applied when updating the `msw` package in the future.
@@ -36,7 +36,7 @@ Let's create a file in our mock definition directory (`src/mocks`) where we woul
 </Action>
 
 ```bash
-$ touch src/mocks/browser.js
+touch src/mocks/browser.js
 ```
 
 In the `browser.js` file we are going to create a worker instance with our request handlers defined earlier.

--- a/docs/getting-started/integrate/node.mdx
+++ b/docs/getting-started/integrate/node.mdx
@@ -14,7 +14,7 @@ Let's create a file in our mock definition directory (`src/mocks`) where we woul
 </Action>
 
 ```bash
-$ touch src/mocks/server.js
+touch src/mocks/server.js
 ```
 
 In the `server.js` file we are going to create a server instance with our request handlers defined earlier.
@@ -73,7 +73,7 @@ If you are not using Create React App, please create a custom setup module and r
 </Action>
 
 ```bash
-$ touch jest.setup.js
+touch jest.setup.js
 ```
 
 Open the `jest.setup.js` file and write there the same code as in the Create React App `src/setupTests.js` example above.

--- a/docs/getting-started/mocks/index.mdx
+++ b/docs/getting-started/mocks/index.mdx
@@ -14,7 +14,7 @@ When working with Mock Service Worker, the list of request handlers, browser- an
 </Action>
 
 ```bash
-$ mkdir src/mocks
+mkdir src/mocks
 ```
 
 Once we have a directory, let's create a module where we will have all our request handlers. The handlers from this module can be reused for both browser and Node in the further steps of this tutorial.
@@ -24,7 +24,7 @@ Once we have a directory, let's create a module where we will have all our reque
 </Action>
 
 ```bash
-$ touch src/mocks/handlers.js
+touch src/mocks/handlers.js
 ```
 
 ## Choose an API

--- a/docs/recipes/debugging-uncaught-requests.mdx
+++ b/docs/recipes/debugging-uncaught-requests.mdx
@@ -98,7 +98,7 @@ Mock Service Worker supports [`debug`](https://github.com/visionmedia/debug) whe
 Append the `DEBUG` environmental variable to the command that runs your tests:
 
 ```bash
-$ DEBUG=* npm test
+DEBUG=* npm test
 ```
 
 With that variable set, you will see many messages in your terminal indicating various stages of request interception that can give you useful hints as to what may have gone wrong.

--- a/docs/recipes/usage-with-cdn.mdx
+++ b/docs/recipes/usage-with-cdn.mdx
@@ -22,5 +22,5 @@ Pick a suitable CDN that can serve NPM modules and include the respective script
 To copy the Service Worker into your public directory, use the `npx msw init` command:
 
 ```bash
-$ npx msw init <PUBLIC_DIR>
+npx msw init <PUBLIC_DIR>
 ```


### PR DESCRIPTION
Remove the leading dollar sign in code blocks to fix errors in the terminal when copying the command to the clipboard