### PR TITLE
Extensions Docs

### DIFF
--- a/docs/api/context/extensions.mdx
+++ b/docs/api/context/extensions.mdx
@@ -3,7 +3,7 @@ title: extensions()
 order: 577
 ---
 
-Returns an extensions payload which can be used as a stand-alone GraphQL response or in conjunction with the [data](/docs/api/context/data) or [errors](/docs/api/context/errors) methods.
+Returns an extensions' payload which can be used as a stand-alone GraphQL response or in conjunction with the [data](/docs/api/context/data) or [errors](/docs/api/context/errors) methods.
 
 ## Call signature
 
@@ -17,14 +17,14 @@ function extensions(payload: Record<string, any>): MockedResponse
 graphql.query('GetTracking', (req, res, ctx) => {
   return res(
     ctx.data({
-      check: 'OK'
+      check: 'OK',
     }),
     ctx.extensions({
       tracking: {
         version: '1.0.1',
-        pageLoadSpeed: 1001
+        pageLoadSpeed: 1001,
       },
-      server: 'Test Server 001'
+      server: 'Test Server 001',
     })
   )
 })

--- a/docs/api/context/extensions.mdx
+++ b/docs/api/context/extensions.mdx
@@ -1,0 +1,31 @@
+---
+title: extensions()
+order: 577
+---
+
+Returns an extensions payload which can be used as a stand-alone GraphQL response or in conjunction with the [data](/docs/api/context/data) or [errors](/docs/api/context/errors) methods.
+
+## Call signature
+
+```ts
+function extensions(payload: Record<string, any>): MockedResponse
+```
+
+## Examples
+
+```js showLineNumbers focusedLines=6-12
+graphql.query('GetTracking', (req, res, ctx) => {
+  return res(
+    ctx.data({
+      check: 'OK'
+    }),
+    ctx.extensions({
+      tracking: {
+        version: '1.0.1',
+        pageLoadSpeed: 1001
+      },
+      server: 'Test Server 001'
+    })
+  )
+})
+```


### PR DESCRIPTION
**Description**

Adding the docs in relation to the recent pull request [981](https://github.com/mswjs/msw/pull/981).

**Comments**

- Left the order the same as `api/context/data.mdx` given it should follow data in the layout.
- Do we want another example of `extensions` being used as a stand-alone or is that pretty self-explanatory. I went with the latter