### PR TITLE
docs: fix error in `waitForRequest` example

### DIFF
--- a/docs/extensions/life-cycle-events/index.mdx
+++ b/docs/extensions/life-cycle-events/index.mdx
@@ -237,7 +237,7 @@ function waitForRequest(method: string, url: string) {
   return new Promise((resolve, reject) => {
     server.events.on('request:start', (req) => {
       const matchesMethod = req.method.toLowerCase() === method.toLowerCase()
-      const matchesUrl = matchRequestUrl(req.url, url)
+      const matchesUrl = matchRequestUrl(req.url, url).matches
 
       if (matchesMethod && matchesUrl) {
         requestId = req.id


### PR DESCRIPTION
`matchRequestUrl` returns a [`Match` object](https://github.com/mswjs/msw/blob/2e7ecd87e5568c6e59a408e812535f088498e437/src/utils/matching/matchRequestUrl.ts#L8-L11), and not a boolean.

Therefore in this example `matchesUrl` was always truthy, even if the request url was not matching.

This fix update the example to use the `matches` property from the `Match` object instead.