### PR TITLE
fix: add options scope config to debugging uncaught requests

### DIFF
--- a/docs/recipes/debugging-uncaught-requests.mdx
+++ b/docs/recipes/debugging-uncaught-requests.mdx
@@ -89,6 +89,19 @@ app.use((req, res, next) => {
 })
 ```
 
+After setting the header on the server, initialize your worker with the corresponding scope by using the options object:
+
+```js focusedLines=8
+worker.start({
+  serviceWorker: {
+    url: '/your/custom/path/mockServiceWorker.js',
+    options: {
+      scope: '/',
+    },
+  },
+});
+```
+
 ## Run in debug mode
 
 - Applicable to: `setupServer`


### PR DESCRIPTION
Hello all,

I recently had the need to follow the instructions under `Debugging uncaught requests`, and more specifically under [Set the Service-Worker-Allowed response header](https://mswjs.io/docs/recipes/debugging-uncaught-requests#set-the-service-worker-allowed-response-header)

After adding the appropriate header in my server, I bumped my head for a while wondering why it still wasn't working, until I realized I needed to provide the additional piece of config to my worker setup:

```
options: { scope: '/' }
```

I was wondering why this wasn't mentioned in the docs, not sure if there's a reason. If not, I thought it'd be pretty neat if the docs mentioned the need for this (although not sure if it would be needed in all cases, or was just a need for my particular setup). Anyway, I added a small section in there that mentions it