### PR TITLE
docs: Improve the return type of waitForRequest

### DIFF
--- a/docs/extensions/life-cycle-events/index.mdx
+++ b/docs/extensions/life-cycle-events/index.mdx
@@ -234,7 +234,7 @@ const server = setupServer(...handlers)
 function waitForRequest(method: string, url: string) {
   let requestId = ''
 
-  return new Promise<MockedRequest<DefaultRequestBody>>((resolve, reject) => {
+  return new Promise<MockedRequest>((resolve, reject) => {
     server.events.on('request:start', (req) => {
       const matchesMethod = req.method.toLowerCase() === method.toLowerCase()
       const matchesUrl = matchRequestUrl(req.url, url).matches

--- a/docs/extensions/life-cycle-events/index.mdx
+++ b/docs/extensions/life-cycle-events/index.mdx
@@ -225,7 +225,7 @@ The life-cycle events API can be used for retrieving a request reference and wri
 </Hint>
 
 ```js
-import { matchRequestUrl, MockedRequest, DefaultRequestBody } from 'msw'
+import { matchRequestUrl, MockedRequest } from 'msw'
 import { setupServer } from 'msw/node'
 import { handlers } from './handlers'
 

--- a/docs/extensions/life-cycle-events/index.mdx
+++ b/docs/extensions/life-cycle-events/index.mdx
@@ -225,7 +225,7 @@ The life-cycle events API can be used for retrieving a request reference and wri
 </Hint>
 
 ```js
-import { matchRequestUrl } from 'msw'
+import { matchRequestUrl, MockedRequest, DefaultRequestBody } from 'msw'
 import { setupServer } from 'msw/node'
 import { handlers } from './handlers'
 
@@ -234,7 +234,7 @@ const server = setupServer(...handlers)
 function waitForRequest(method: string, url: string) {
   let requestId = ''
 
-  return new Promise((resolve, reject) => {
+  return new Promise<MockedRequest<DefaultRequestBody>>((resolve, reject) => {
     server.events.on('request:start', (req) => {
       const matchesMethod = req.method.toLowerCase() === method.toLowerCase()
       const matchesUrl = matchRequestUrl(req.url, url).matches


### PR DESCRIPTION
`waitForRequest` always returns `unknown ` in TypeScript.

```ts
const pendingRequest = waitForRequest('POST', '/login');

const request = await pendingRequest;

// Object is of type 'unknown'.ts(2571)
expect(request.body).toEqual({
  email: 'user@example.com',
  password: 'super+secret123',
})
```

So, i want to improve the return type of waitForRequest  in the docs.