### PR TITLE
chore: Add SvelteKit to the public directory table

### DIFF
--- a/docs/snippets/public-dir.mdx
+++ b/docs/snippets/public-dir.mdx
@@ -16,6 +16,7 @@ Below you can find a list of public directories in most used JavaScript project 
 | [Preact](https://preactjs.com)                   | `./src/static`                                                  |
 | [Ember.js](https://emberjs.com/)                 | `./public`                                                      |
 | [Svelte.js](https://svelte.dev/)                 | `./public`                                                      |
+| [SvelteKit](https://kit.svelte.dev/)             | `./static`                                                      |
 | [Vite](https://vitejs.dev/)                      | `./public`                                                      |
 
 <Hint>


### PR DESCRIPTION
I've just came across this page in the way trying msw to my SvelteKIt app and found it isn't there yet. Hopefully this helps.

cite: https://kit.svelte.dev/docs/configuration