### PR TITLE
docs: fix typo

### DIFF
--- a/docs/getting-started/integrate/browser.mdx
+++ b/docs/getting-started/integrate/browser.mdx
@@ -114,7 +114,7 @@ Let's say that your `package.json` has the following line:
 "homepage": "/login/"
 ```
 
-Your development environment will automatically open using `localhost:3000/login`, without `/` at the end and your service worker will not work as expected. For this reason we have to update our `src/index.js` or `src/index.tsx` where we rewrite `windows.location.pathname` string with `/` at the end:
+Your development environment will automatically open using `localhost:3000/login`, without `/` at the end and your service worker will not work as expected. For this reason we have to update our `src/index.js` or `src/index.tsx` where we rewrite `window.location.pathname` string with `/` at the end:
 
 ```js showLineNumbers focusedLines=8-17
 // src/index.js


### PR DESCRIPTION
Replaces `windows` with `window` in the "Browser - Getting Started" page.