### PR TITLE
Fixing docs about response composition

### DIFF
--- a/docs/recipes/custom-response-composition.mdx
+++ b/docs/recipes/custom-response-composition.mdx
@@ -39,7 +39,7 @@ export const handlers = [
   rest.get('/user', (req, res, ctx) => {
     // This mocked response has realistic
     // response time automatically.
-    return delayedResponse(
+    return delayedResponse(() =>
       ctx.json({
         firstName: 'John',
         lastName: 'Maverick',


### PR DESCRIPTION
It seems that a response composition wants a function (returning a response) as a parameter, not a response object.