### PR TITLE
Update FAQ on React Native support

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -29,11 +29,11 @@ Mock Service Worker provides a Node-compatible API to allow you to reuse the sam
 
 ## Can I use it with React Native?
 
-Yes, but only for NodeJS integration.
+Yes, but because MSW relies on running a Node process, it can only be used for local development in the simulator or running unit/integration tests.
 
-Since React Native does not execute in a browser environment, you cannot run a Service Worker alongside your application.
+Since React Native does not support certain Node.js globals, like `URL`, you will need to add polyfills to patch the global environment by adding `react-native-url-polyfill` and `import { setupServer } from 'msw/native'`.
+For running unit/integration tests, use `import { setupServer } from 'msw/node'`.
 
-However, you can use Mock Service Worker in your React Native project for unit and integration tests that run in Node.
 Please see the following page for the integration steps:
 
 <PageLink


### PR DESCRIPTION
This revises the FAQ to describe that React Native is largely supported, as discussed in [this issue](https://github.com/mswjs/msw/issues/203#issuecomment-1278868131).

@kettanaito I see that you have an [unmerged branch](https://github.com/mswjs/mswjs.io/tree/docs/react-native) `docs/react-native`. Is that up to date? Can it be merged soon too?