### PR TITLE
Update code example to use ctx.data instead of ctx.json

### DIFF
--- a/docs/getting-started/integrate/node.mdx
+++ b/docs/getting-started/integrate/node.mdx
@@ -113,7 +113,7 @@ Bear in mind that without a DOM-like environment, like the jsdom from Jest, **yo
 const server = setupServer(
   // NOT "/user", nothing to be relative to!
   rest.get('https://api.backend.dev/user', (req, res, ctx) => {
-    return res(ctx.json({ firstName: 'John' }))
+    return res(ctx.data({ firstName: 'John' }))
   }),
 )
 ```


### PR DESCRIPTION
`ctx.json` is not used, and it is recommended to use `ctx.data` to return data in request handlers. This pull request updates the code example in the documentation to reflect this change and avoid confusion.