### PR TITLE
docs / update the description of `delay`

### DIFF
--- a/docs/api/context/delay.mdx
+++ b/docs/api/context/delay.mdx
@@ -48,7 +48,7 @@ rest.post('/login', (req, res, ctx) => {
 
 ### Implicit response delay
 
-When no delay duration is explicitly provided, Mock Service Worker uses a random realistic server response time on the particular mocked response.
+When no delay duration is explicitly provided or `'real'` is given, Mock Service Worker uses a random realistic server response time on the particular mocked response.
 
 ```js showLineNumbers focusedLines=3
 rest.delete('/post/:postId', (req, res, ctx) => {

--- a/docs/api/context/delay.mdx
+++ b/docs/api/context/delay.mdx
@@ -29,6 +29,23 @@ rest.post('/login', (req, res, ctx) => {
 })
 ```
 
+### Infinite response delay
+
+You can give `'infinite'` instead of a duration (in ms). Mock Service Worker will never response anything virtually.
+
+
+```js showLineNumbers focusedLines=3-4
+rest.post('/login', (req, res, ctx) => {
+  return res(
+    // Delays response infinitely.
+    ctx.delay('infinite'),
+    ctx.json({
+      message: 'This message will never be read...',
+    }),
+  )
+})
+```
+
 ### Implicit response delay
 
 When no delay duration is explicitly provided, Mock Service Worker uses a random realistic server response time on the particular mocked response.

--- a/docs/api/context/delay.mdx
+++ b/docs/api/context/delay.mdx
@@ -10,7 +10,7 @@ Delays the response by the given duration (in ms). When no duration is provided,
 ## Call signature
 
 ```ts
-function delay(duration?: number): MockedResponse
+function delay(duration?: number | 'infinite' | 'real'): MockedResponse
 ```
 
 ## Examples


### PR DESCRIPTION
close https://github.com/mswjs/mswjs.io/issues/160
ref: https://mswjs.io/docs/api/context/delay

We can use `'infinite'` or `'real'` as an args of `delay` function, but the document is not updated for that.
I updated the document referring to [this source code](https://github.com/mswjs/msw/blob/da92465b312b54a7a7e71168b1bdcb62daeef3b1/src/context/delay.ts).