### PR TITLE
docs: fix two typos

### DIFF
--- a/src/content/docs/api/graphql.mdx
+++ b/src/content/docs/api/graphql.mdx
@@ -174,7 +174,7 @@ export const handlers = [
 
 > Although the name of the `GetPayment` query is the same, it will be handled differently depending on the requested endpoint.
 
-### `graphl.operation(resolver)`
+### `graphql.operation(resolver)`
 
 The `.operation()` method intercepts all GraphQL operations regardless of their type and name. It's designed to cover the following scenarios:
 

--- a/src/content/docs/network-behavior/graphql.mdx
+++ b/src/content/docs/network-behavior/graphql.mdx
@@ -159,7 +159,7 @@ import { Warning } from '../../../components/react/warning'
 <Warning>
   Prefer _named queries_ in order to use the `graphql.query()` and
   `graphql.mutation()` request handlers. For anonymous GraphQL queries, use the
-  [`graphql.operation()`](/docs/api/graphql#graphloperationresolver) API
+  [`graphql.operation()`](/docs/api/graphql#graphqloperationresolver) API
   instead.
 </Warning>
 

--- a/src/content/docs/network-behavior/graphql.mdx
+++ b/src/content/docs/network-behavior/graphql.mdx
@@ -291,7 +291,7 @@ The `query` object is useful if you want to resolve the intercepted GraphQL oper
 
 One of the reasons to adopt GraphQL is to fetch only the data the client needs. When mocking the GraphQL responses with MSW, however, the entire mock data will be sent to the client as-is, regardless of the fields it queries.
 
-For example, if the client decides to dorp the `title` field on the `ListPosts` query, it will still receive that field if it's sent in the mock response. That is because MSW does no field matching that a regular GraphQL server would do when resolving the incoming queries.
+For example, if the client decides to drop the `title` field on the `ListPosts` query, it will still receive that field if it's sent in the mock response. That is because MSW does no field matching that a regular GraphQL server would do when resolving the incoming queries.
 
 You can match the behavior of an actual GraphQL server more closely by resolving the intercepted queries using the `graphql` package. This approach requires you to define the GraphQL schema and forward the operation name, query, and variables of the intercepted GraphQL operations to be resolved against a mock root value.
 

--- a/src/content/docs/recipes/mock-graphql-schema.mdx
+++ b/src/content/docs/recipes/mock-graphql-schema.mdx
@@ -9,7 +9,7 @@ keywords:
 
 When [describing GraphQL APIs](/docs/network-behavior/graphql), the responses returned from response resolvers will be sent to the client as-is, even if they include extra properties not present in the original query. While this allows to get started with a GraphQL API without having to define schemas and resolvers, such behavior is not what one would expect from an actual GraphQL server.
 
-You can resolve intercepted GraphQL operations against a mocked GraphQL schema using the [`graphql`](npmjs.com/package/graphql) package. In the example below, we will also use the [`graphql.operation()`](/docs/api/graphql#graphloperationresolver) request handler to resolve them against the schema.
+You can resolve intercepted GraphQL operations against a mocked GraphQL schema using the [`graphql`](npmjs.com/package/graphql) package. In the example below, we will also use the [`graphql.operation()`](/docs/api/graphql#graphqloperationresolver) request handler to resolve them against the schema.
 
 ```js {2,4-13,24-33}
 import { graphql } from 'msw'


### PR DESCRIPTION
There were two typos, one in a heading (plus two links linking to it) and another mis-spelled "drop".