### PR TITLE
fix incorrect wording on node.js requirement

### DIFF
--- a/src/content/docs/migrations/1.x-to-2.x.mdx
+++ b/src/content/docs/migrations/1.x-to-2.x.mdx
@@ -708,7 +708,7 @@ In addition to the breaking changes, this release introduces a list of new APIs.
 
 #### Upgrade your Node.js version
 
-Make sure you are using Node.js v18 or older. Run `node -v` and see the current Node.js version. If it's lower than 18, upgrade.
+Make sure you are using Node.js v18 or later. Run `node -v` and see the current Node.js version. If it's lower than 18, upgrade.
 
 #### Remap Fetch API globals
 


### PR DESCRIPTION
Awesome work and congrats on the 2.0 release! Had to read and see if my whines somehow made it onto the docs haha.

Just found this wording which I assume was meant to infer a later version of node, not an **older** version. I assume you don't want people moving to Node v8 to run msw2.