### PR TITLE
Fix typos in migration guide

### DIFF
--- a/src/content/docs/migrations/1.x-to-2.x.mdx
+++ b/src/content/docs/migrations/1.x-to-2.x.mdx
@@ -714,7 +714,7 @@ Create a `jest.polyfills.js` file next to your `jest.config.js` with the followi
 // jest.polyfills.js
 const { TextEncoder, TextDecoder } = require('node:util')
 
-Reflect.set(globalThis, 'TextEncoder', TextDecoder)
+Reflect.set(globalThis, 'TextEncoder', TextEncoder)
 Reflect.set(globalThis, 'TextDecoder', TextDecoder)
 
 const { Blob } = require('node:buffer')
@@ -723,7 +723,7 @@ const { fetch, Request, Response, Headers, FormData } = require('undici')
 Reflect.set(globalThis, 'fetch', fetch)
 Reflect.set(globalThis, 'Blob', Blob)
 Reflect.set(globalThis, 'Request', Request)
-Reflect.set(globalThis, 'Respose', Respose)
+Reflect.set(globalThis, 'Response', Response)
 Reflect.set(globalThis, 'Headers', Headers)
 Reflect.set(globalThis, 'FormData', FormData)
 ```


### PR DESCRIPTION
- `TextDecoder` was being used as both `TextDecoder` _and_ `TextEncoder`
- "Respose" -> "Response" (also covered in #274, looks like we were doing this at the same time...)