### PR TITLE
add null and undefined to HttpResponse body argument type

### DIFF
--- a/src/content/docs/api/http-response.mdx
+++ b/src/content/docs/api/http-response.mdx
@@ -31,7 +31,9 @@ class HttpResponse {
       | FormData
       | ReadableStream
       | URLSearchParams
-      | string,
+      | string
+      | null
+      | undefined
     options?: {
       status?: number
       statusText?: string


### PR DESCRIPTION
To prevent confusion whether those values are allowed. They are. 