### PR TITLE
add jest.useFakeTimers() to the runbook

### DIFF
--- a/src/content/docs/runbook.mdx
+++ b/src/content/docs/runbook.mdx
@@ -133,3 +133,22 @@ beforeEach(() => {
   cache.clear()
 })
 ```
+
+---
+
+### Requests are not resolving when using `jest.useFakeTimers`
+
+When configuring `useFakeTimers` in jest, all timer apis are mocked including `queueMicrotask`. `queueMicrotask` is used internally by unidici (the modern nodejs fetch library) while parsing response bodies. Because of this, when using `useFakeTimers` with the default configuration, body reading methods like `await request.text()` and `await request.json()` will not resolve properly.
+
+<Success>Configure jest not to mock calls to `queueMicrotask`</Success>
+
+> Please refer to jest's [documentation on fake timers](https://jestjs.io/docs/timer-mocks#selective-faking)
+
+For example, here's how to disable faking of `queueMicrotask` when using jest fake timers
+
+```js {3}
+jest.useFakeTimers({
+  // configure jest to not fake `queueMicrotask` calls
+  doNotFake: ['queueMicrotask']
+})
+```

--- a/src/content/docs/runbook.mdx
+++ b/src/content/docs/runbook.mdx
@@ -138,17 +138,17 @@ beforeEach(() => {
 
 ### Requests are not resolving when using `jest.useFakeTimers`
 
-When configuring `useFakeTimers` in jest, all timer apis are mocked including `queueMicrotask`. `queueMicrotask` is used internally by unidici (the modern nodejs fetch library) while parsing response bodies. Because of this, when using `useFakeTimers` with the default configuration, body reading methods like `await request.text()` and `await request.json()` will not resolve properly.
+When using fake timers in Jest, all timer APIs are mocked, including `queueMicrotask`. The `queueMicrotask` API is used internally by the global fetch in Node.js to parse request/response bodies. Because of this, when using `jest.useFakeTimers()` with the default configuration, body reading methods like `await request.text()` and `await request.json()` will not resolve properly.
 
-<Success>Configure jest not to mock calls to `queueMicrotask`</Success>
+<Success>Configure Jest not to mock calls to `queueMicrotask`</Success>
 
-> Please refer to jest's [documentation on fake timers](https://jestjs.io/docs/timer-mocks#selective-faking)
-
-For example, here's how to disable faking of `queueMicrotask` when using jest fake timers
+For example, here's how to prevent Jest from faking the `queueMicrotask` calls when using `jest.useFakeTimers()`:
 
 ```js {3}
 jest.useFakeTimers({
-  // configure jest to not fake `queueMicrotask` calls
+  // Explicitly tell Jest not to affect the "queueMicrotask" calls.
   doNotFake: ['queueMicrotask']
 })
 ```
+
+> Please refer to Jest's [documentation on fake timers](https://jestjs.io/docs/timer-mocks#selective-faking).


### PR DESCRIPTION
Update runbook to discuss selective faking of fake timers in jest

<img width="729" alt="Screen Shot 2023-11-04 at 11 50 49 AM" src="https://github.com/mswjs/mswjs.io/assets/8616962/8b3ffbb4-dee6-4e19-9360-e589825a811c">
