### PR TITLE
reuse jest missing globals solution

### DIFF
--- a/src/content/docs/faq.mdx
+++ b/src/content/docs/faq.mdx
@@ -60,33 +60,11 @@ This error means that the version of Node.js you're using doesn't support the gl
 
 Resolve this by upgrading to Node.js version 18 or higher. MSW does not support Node.js versions below version 18.
 
-## ReferenceError: `Request` is not defined in Jest
+## `Request`/`Response`/`TextEncoder` is not defined (Jest)
 
-This error means that the global `Request` class is not available in your current environment.
+import JestMissingGlobals from './shared/jest-missing-globals.mdx'
 
-First, make sure you're running Node.js version 18 or higher:
-
-```bash
-node -v
-# v18.14.0
-```
-
-Once you do, you have to explicitly tell Jest to allow Fetch API globals in your test run:
-
-```js
-// jest.config.js
-module.exports = {
-  globals: {
-    Request,
-    Response,
-    Headers,
-    Blob,
-    FormData,
-  },
-}
-```
-
-> You don't have to import any of those globals—they ship with Node.js.
+<JestMissingGlobals />
 
 ## Why should I drop query parameters from the request handler URL?
 

--- a/src/content/docs/migrations/1.x-to-2.x.mdx
+++ b/src/content/docs/migrations/1.x-to-2.x.mdx
@@ -702,50 +702,9 @@ In addition to the breaking changes, this release introduces a list of new APIs.
 
 ### `Request`/`Response`/`TextEncoder` is not defined (Jest)
 
-<Warning>
-  Make sure you are using Node.js v18 or newer before reading further.
-</Warning>
+import JestMissingGlobals from '../shared/jest-missing-globals.mdx'
 
-This issue is caused by your environment not having the Node.js globals for one reason or another. This commonly happens in Jest because it intentionally robs you of Node.js globals and fails to re-add them in their entirely. As the result, you have to explicitly add them yourself.
-
-Create a `jest.polyfills.js` file next to your `jest.config.js` with the following content:
-
-```js
-// jest.polyfills.js
-const { TextEncoder, TextDecoder } = require('node:util')
-
-Reflect.set(globalThis, 'TextEncoder', TextEncoder)
-Reflect.set(globalThis, 'TextDecoder', TextDecoder)
-
-const { Blob } = require('node:buffer')
-const { fetch, Request, Response, Headers, FormData } = require('undici')
-
-Reflect.set(globalThis, 'fetch', fetch)
-Reflect.set(globalThis, 'Blob', Blob)
-Reflect.set(globalThis, 'Request', Request)
-Reflect.set(globalThis, 'Response', Response)
-Reflect.set(globalThis, 'Headers', Headers)
-Reflect.set(globalThis, 'FormData', FormData)
-```
-
-> Make sure to install `undici` as a dev dependency in your project. Undici is the official implementation of global `fetch` in Node.js.
-
-Then, set the `setupFiles` option in `jest.config.js` to point to the newly created `jest.polyfills.js`:
-
-```js {3}
-// jest.config.js
-module.exports = {
-  setupFiles: ['./jest.polyfills.js'],
-}
-```
-
-<Warning>
-  Pay attention it's the `setupFiles` option, and _not_ `setupFilesAfterEnv`.
-  The missing Node.js globals must be injected _before_ the environment (e.g.
-  JSDOM).
-</Warning>
-
-If you find this setup cumbersome, consider migrating to a modern testing framework, like [Vitest](https://vitest.dev/), which has none of the Node.js globals issues and provides native ESM support out of the box.
+<JestMissingGlobals />
 
 ### Cannot find module 'msw/node' (JSDOM)
 

--- a/src/content/docs/shared/jest-missing-globals.mdx
+++ b/src/content/docs/shared/jest-missing-globals.mdx
@@ -1,0 +1,42 @@
+---
+title: Jest missing globals
+---
+
+import { Warning } from '../../../components/react/warning'
+
+<Warning>
+  Make sure you are using Node.js v18 or newer before reading further.
+</Warning>
+
+This issue is caused by your environment not having the Node.js globals for one reason or another. This commonly happens in Jest because it intentionally robs you of Node.js globals and fails to re-add them in their entirely. As the result, you have to explicitly add them yourself.
+
+Create a `jest.polyfills.js` file next to your `jest.config.js` with the following content:
+
+```js
+// jest.polyfills.js
+Reflect.set(globalThis, 'TextEncoder', TextEncoder)
+Reflect.set(globalThis, 'TextDecoder', TextDecoder)
+Reflect.set(globalThis, 'fetch', fetch)
+Reflect.set(globalThis, 'Blob', Blob)
+Reflect.set(globalThis, 'Request', Request)
+Reflect.set(globalThis, 'Response', Response)
+Reflect.set(globalThis, 'Headers', Headers)
+Reflect.set(globalThis, 'FormData', FormData)
+```
+
+Then, set the `setupFiles` option in `jest.config.js` to point to the newly created `jest.polyfills.js`:
+
+```js {3}
+// jest.config.js
+module.exports = {
+  setupFiles: ['./jest.polyfills.js'],
+}
+```
+
+<Warning>
+  Pay attention it's the `setupFiles` option, and _not_ `setupFilesAfterEnv`.
+  The missing Node.js globals must be injected _before_ the environment (e.g.
+  JSDOM).
+</Warning>
+
+If you find this setup cumbersome, consider migrating to a modern testing framework, like [Vitest](https://vitest.dev/), which has none of the Node.js globals issues and provides native ESM support out of the box.


### PR DESCRIPTION
We list different suggestions in FAQ and 1.x -> 2.x migration guidelines regarding `Request` is not defined in Jest. Unify those. 