### PR TITLE
Update jest-missing-globals.mdx to use nodejs File

### DIFF
--- a/src/content/docs/shared/jest-missing-globals.mdx
+++ b/src/content/docs/shared/jest-missing-globals.mdx
@@ -31,12 +31,13 @@ Object.defineProperties(globalThis, {
   TextEncoder: { value: TextEncoder },
 })
 
-const { Blob } = require('node:buffer')
+const { Blob, File } = require('node:buffer')
 const { fetch, Headers, FormData, Request, Response } = require('undici')
 
 Object.defineProperties(globalThis, {
   fetch: { value: fetch, writable: true },
   Blob: { value: Blob },
+  File: { value: File },
   Headers: { value: Headers },
   FormData: { value: FormData },
   Request: { value: Request },


### PR DESCRIPTION
When using jsdom this value conflicts with jsdom's own `Blob` and `File`, importing and specifying here that we want the global value to be the one from node avoids that.

This was reproducible if you tried to do something like this (assuming you'd copy-pasted the snippet I've edited across to your jest test setup):
```js
const data = new FormData(); // this FormData is the nodejs one
const myFile = new File(['some,file,contents', 'filename.csv', { type: 'text/csv' }) // this File is the jsdom one

data.append('fileInput', myFile, myFile.name)
// throws with:
// TypeError: Failed to execute 'append' on 'FormData': parameter 2 is not of type 'Blob'
```

In addition/to verify:

Before:
```js
const myFile = new File(['some,file,contents', 'filename.csv', { type: 'text/csv' })

myFile instanceof Blob; // false (because Blob is the jsdom one)
myFile instanceof File; // true
```

After:
```
const myFile = new File(['some,file,contents', 'filename.csv', { type: 'text/csv' })

myFile instanceof Blob; // true
myFile instanceof File; // true
```