### PR TITLE
docs: Change argument list to a single argument in `custom-request-predicate.mdx`

### DIFF
--- a/src/content/docs/best-practices/custom-request-predicate.mdx
+++ b/src/content/docs/best-practices/custom-request-predicate.mdx
@@ -18,7 +18,7 @@ You can implement a custom request predicate using a [higher-order resolver](/do
 import { passthrough } from 'msw'
 
 export function withSearchParams(predicate, resolver) {
-  return (...args) => {
+  return (args) => {
     const { request } = args
     const url = new URL(request.url)
 
@@ -26,7 +26,7 @@ export function withSearchParams(predicate, resolver) {
       return passthrough()
     }
 
-    return resolver(...args)
+    return resolver(args)
   }
 }
 ```
@@ -66,7 +66,7 @@ Implementing a custom request body predicate is no different from the query pred
 import isEqual from 'lodash.isequal'
 
 export function withJsonBody(expectedBody, resolver) {
-  return async (...args) => {
+  return async (args) => {
     const { request } = args
 
     // Ignore requests that have a non-JSON body.
@@ -83,7 +83,7 @@ export function withJsonBody(expectedBody, resolver) {
       return
     }
 
-    return resolver(...args)
+    return resolver(args)
   }
 }
 ```


### PR DESCRIPTION
First of all: Thank you for the great library :heart:

This PR contains a small fix for the examples in `custom-request-predicate.mdx`. Since `args` is in the current version a list deconstructing `request` via `const { request } = args` does not work. Since a resolver has only one argument in the current type definitions, it should be okay to change the function in this was.

There would be another fix by writing `const { request } = args[0]`.