### PR TITLE
fix: broken links to page 'network-behavior-overrides' #302

### DIFF
--- a/src/content/docs/api/setup-server/reset-handlers.mdx
+++ b/src/content/docs/api/setup-server/reset-handlers.mdx
@@ -32,5 +32,5 @@ server.resetHandlers(http.patch('/book/:bookId', resolver))
 
 ## Related materials
 
-- [Network behavior overrides](/docs/recipes/network-behavior-overrides)
+- [Network behavior overrides](/docs/best-practices/network-behavior-overrides)
 - [`worker.resetHandler()`](/docs/api/setup-worker/reset-handlers)

--- a/src/content/docs/api/setup-server/use.mdx
+++ b/src/content/docs/api/setup-server/use.mdx
@@ -20,4 +20,4 @@ The prepended request handlers persist on the server instance as long as the cur
 ## Related materials
 
 - [Runtime request handlers](/docs/basics/request-handler#runtime-request-handlers)
-- [Network behavior overrides](/docs/recipes/network-behavior-overrides)
+- [Network behavior overrides](/docs/best-practices/network-behavior-overrides)


### PR DESCRIPTION
Fix issue #302 

Links from https://mswjs.io/docs/api/setup-server/use page and https://mswjs.io/docs/api/setup-server/reset-handlers page to "Network Behavior Overrides" were broken.

Replaced with the correct link
https://mswjs.io/docs/best-practices/network-behavior-overrides/