### PR TITLE
fix responding with binary usage

### DIFF
--- a/src/content/docs/recipes/responding-with-binary.mdx
+++ b/src/content/docs/recipes/responding-with-binary.mdx
@@ -49,7 +49,9 @@ export const handlers = [
     )
 
     return HttpResponse.arrayBuffer(buffer, {
-      'Content-Type': 'video/mp4',
+      headers: {
+        'Content-Type': 'video/mp4',
+      },
     })
   }),
 ]


### PR DESCRIPTION
I found that the second argument of HttpResponse.arrayBuffer requires a headers key, similar to the Browser item. 