### PR TITLE
docs: fix broken table

### DIFF
--- a/src/content/docs/concepts/response-resolver.mdx
+++ b/src/content/docs/concepts/response-resolver.mdx
@@ -39,9 +39,9 @@ http.post('/post/:postId', async ({ request, params, cookies }) => {
 The data below is available for every intercepted request, regardless if it's a REST API or a GraphQL request.
 
 | Name        | Type                                                                          | Description                                                  |
-| ----------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------ | --- |
+| ----------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | `request`   | [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request) | Fetch API Request representation of the intercepted request. |
-| `requestId` | `string`                                                                      | A UUID string identifier for the intercepted request.        | .   |
+| `requestId` | `string`                                                                      | A UUID string identifier for the intercepted request.        |
 | `cookies`   | `Record<string, string>`                                                      | Request cookies.                                             |
 | `params`    | `Record<string, string[] \| string>`                                          | Request path parameters.                                     |
 


### PR DESCRIPTION
Hi.
I found an invalid markdown table in the docs.
https://mswjs.io/docs/concepts/response-resolver

<img width="1678" alt="CleanShot 2024-01-23 at 22 58 37@2x" src="https://github.com/mswjs/mswjs.io/assets/70504137/22661044-6c25-415a-980d-3d1ea375041a">
