### PR TITLE
mention "document.baseURI" polyfill in relative URLs with Node.js

### DIFF
--- a/src/content/docs/basics/intercepting-requests.mdx
+++ b/src/content/docs/basics/intercepting-requests.mdx
@@ -195,7 +195,7 @@ export const handlers = [
 
 ### How do I use relative URLs in Node.js?
 
-You don't. In Node.js, there is nothing to be relative to. If you are describing a network behavior for a Node.js application, use the absolute URLs you are requesting. If you are using MSW with a Node.js-based test runner, like Jest or Vitest, configure those runners accordingly to support relative URLs (i.e. polyfill the `window.location` object).
+You don't. In Node.js, there is nothing to be relative to. If you are describing a network behavior for a Node.js application, use the absolute URLs you are requesting. If you are using MSW with a Node.js-based test runner, like Jest or Vitest, configure those runners accordingly to support relative URLs (i.e. polyfill the `document.baseURI` string).
 
 ## Related materials
 


### PR DESCRIPTION
According to `getAbsoluteUrl` function [implementation](https://github.com/mswjs/msw/blob/main/src/core/utils/url/getAbsoluteUrl.ts#L20), `document.baseURI` should be polyfilled, not `window.location`.