### PR TITLE
docs: Fix conditional mocking example

### DIFF
--- a/src/content/docs/integrations/browser.mdx
+++ b/src/content/docs/integrations/browser.mdx
@@ -59,7 +59,7 @@ import { App } from './App'
 
 async function enableMocking() {
   if (process.env.NODE_ENV !== 'development') {
-    return
+    return Promise.resolve()
   }
 
   const { worker } = await import('./mocks/browser')


### PR DESCRIPTION
`enableMocking()` should always return a Promise.