### PR TITLE
Include `@latest` version specifier for npm install

### DIFF
--- a/src/content/docs/getting-started.mdx
+++ b/src/content/docs/getting-started.mdx
@@ -11,7 +11,7 @@ Developers come to MSW for various reasons: to establish proper testing boundari
 Install MSW as a dependency by running the following command in your project:
 
 ```
-npm install msw --save-dev
+npm install msw@latest --save-dev
 ```
 
 > If you need to, you can also [install MSW from a CDN](/docs/recipes/using-cdn).


### PR DESCRIPTION
Without the `@latest` version specifier, doing an install can sometimes install an older or cached version of the package.