### PR TITLE
fix: add missing `await` keyword

### DIFF
--- a/src/content/docs/api/get-response.mdx
+++ b/src/content/docs/api/get-response.mdx
@@ -38,6 +38,6 @@ const handlers = [
 const request = new Request('/user')
 
 const response = await getResponse(handlers, request)
-const user = response?.json()
+const user = await response?.json()
 // {"name":"John"}
 ```


### PR DESCRIPTION
The [Response: json()](https://developer.mozilla.org/en-US/docs/Web/API/Response/json) method returns a `Promise`, so it should add `await` in this example.