### PR TITLE
Update jest-missing-globals.mdx

### DIFF
--- a/src/content/docs/shared/jest-missing-globals.mdx
+++ b/src/content/docs/shared/jest-missing-globals.mdx
@@ -25,10 +25,12 @@ Create a `jest.polyfills.js` file next to your `jest.config.js` with the followi
  */
 
 const { TextDecoder, TextEncoder } = require('node:util')
+const { ReadableStream } = require('stream/web')
 
 Object.defineProperties(globalThis, {
   TextDecoder: { value: TextDecoder },
   TextEncoder: { value: TextEncoder },
+  ReadableStream: { value: ReadableStream },
 })
 
 const { Blob, File } = require('node:buffer')


### PR DESCRIPTION
Updated the jest-missing-globals doc to fix the common issue related to ReadableStream not being defined as of Jest V29.

Was facing this issue in my own project, opened a ticket then closed it on the MSW repo, because ReadableStream wasn't defined causing errors HttpResponse to fail. ReadableStream needs to be defined because it's one of those global libraries that Jest ignores and you have to reintroduce to the environment. 