### PR TITLE
Update RN docs to include needed Node version

### DIFF
--- a/src/content/docs/integrations/react-native.mdx
+++ b/src/content/docs/integrations/react-native.mdx
@@ -111,6 +111,6 @@ For end-to-end testing, make sure you have [Enabled MSW in development](#develop
 
 ### Network request fails with `TypeError: Failed to fetch`
 
-**Reason:** `/node_modules/@mswjs/interceptors/src/interceptors/fetch/index.ts` throws at `createNetworkError` because your `Node` version is not `≥18.17`
+**Reason:** `/node_modules/@mswjs/interceptors/src/interceptors/fetch/index.ts` throws at `createNetworkError` because your `Node` version is not `≥18.16`
 
-**Solution:** Upgrade your Node version to `≥18.17`.
+**Solution:** Upgrade your Node version to `≥18.16`.

--- a/src/content/docs/integrations/react-native.mdx
+++ b/src/content/docs/integrations/react-native.mdx
@@ -108,3 +108,9 @@ For end-to-end testing, make sure you have [Enabled MSW in development](#develop
 -import { setupServer } from 'msw/node'
 +import { setupServer } from 'msw/native'
 ```
+
+### Network request fails with `TypeError: Failed to fetch`
+
+**Reason:** `/node_modules/@mswjs/interceptors/src/interceptors/fetch/index.ts` throws at `createNetworkError` because your `Node` version is not `≥18.17`
+
+**Solution:** Upgrade your Node version to `≥18.17`.


### PR DESCRIPTION
We found out in the team that when Node is on <18.16, MSW throws an error on all network requests. This was fixed by updating to >=18.16. Node updated its url parser with a new one called Ada in 18.16, which might be why older versions does not work.