### PR TITLE
fix: add missing type parameter to `withDelay` example

### DIFF
--- a/src/content/docs/best-practices/typescript.mdx
+++ b/src/content/docs/best-practices/typescript.mdx
@@ -200,7 +200,7 @@ function withDelay<
   Params extends PathParams,
   RequestBodyType extends DefaultBodyType,
   ResponseBodyType extends DefaultBodyType
->(durationMs: number, resolver: HttpResponseResolver): HttpResponseResolver {
+>(durationMs: number, resolver: HttpResponseResolver<Params, RequestBodyType, ResponseBodyType>): HttpResponseResolver<Params, RequestBodyType, ResponseBodyType> {
   return async (...args) => {
     await delay(durationMs)
     return resolver(...args)


### PR DESCRIPTION
The example code of [withDelay](https://mswjs.io/docs/best-practices/typescript#higher-order-response-resolvers) seems to be cause type error due to the lack of type parameter of `HttpResponseResolver`.

This patch may not the best, but it works collectly.