### PR TITLE
fix: valid URI and URL for `getResponse` example to work every environment

### DIFF
--- a/src/content/docs/api/get-response.mdx
+++ b/src/content/docs/api/get-response.mdx
@@ -31,7 +31,7 @@ import { CodeBracketSquareIcon } from '@heroicons/react/24/outline'
 import { http, HttpResponse, getResponse } from 'msw'
 
 const handlers = [
-  http.get('*/user', () => {
+  http.get('http://localhost/user', () => {
     return HttpResponse.json({ name: 'John' })
   }),
 ]

--- a/src/content/docs/api/get-response.mdx
+++ b/src/content/docs/api/get-response.mdx
@@ -31,11 +31,11 @@ import { CodeBracketSquareIcon } from '@heroicons/react/24/outline'
 import { http, HttpResponse, getResponse } from 'msw'
 
 const handlers = [
-  http.get('/user', () => {
+  http.get('*/user', () => {
     return HttpResponse.json({ name: 'John' })
   }),
 ]
-const request = new Request('/user')
+const request = new Request('http://localhost/user')
 
 const response = await getResponse(handlers, request)
 const user = await response?.json()


### PR DESCRIPTION
The current `getResponse` example code works only browser due to that the [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request) constructor generate a URL from the URI like `/user`.
But it don't act well non-browser environment like node because of it requires URL.
We should show better for both environment.

I picked it from here.
https://github.com/mswjs/msw/blob/ad8ebac0c6b3c1dd66bf275b8c9d06370607e9c6/src/core/getResponse.test.ts#L41-L44
