### PR TITLE
Update polling.mdx

### DIFF
--- a/src/content/docs/recipes/polling.mdx
+++ b/src/content/docs/recipes/polling.mdx
@@ -27,7 +27,6 @@ export const handlers = [
       yield HttpResponse.json({ degree: degree })
     }
 
-    degree++
     return HttpResponse.json({ degree: degree })
   }),
 ]


### PR DESCRIPTION
Just noticed this: since the comment says "all subsequent requests will respond with the latest returned response" with 28 a second time my understanding is that the handler would _not_ increment `degree` before the return.