### PR TITLE
docs: Add `onUnhandledRequest` to MSW 2.0 migration docs

### DIFF
--- a/websites/mswjs.io/src/content/docs/migrations/1.x-to-2.x.mdx
+++ b/websites/mswjs.io/src/content/docs/migrations/1.x-to-2.x.mdx
@@ -70,6 +70,41 @@ import { setupWorker } from 'msw'
 import { setupWorker } from 'msw/browser'
 ```
 
+### onUnhandledRequest
+
+The `request` argument from `onUnhandledRequest` has changed to be closer to the standards. Before, it returned an object close to the Request specs, but now it returns an actual Request. A breaking change that can affect your code is the `url` property, which before was of type `Url` but now it is of type `string`.
+
+**Before:**
+
+```js
+server.listen({
+  onUnhandledRequest(request, print) {
+    const url = request.url
+ 
+    if (url.pathname.includes('/assets/')) {
+      return
+    }
+    print.warning()
+  },
+})
+```
+
+**After:**
+
+```js
+server.listen({
+  onUnhandledRequest(request, print) {
+    // You must instantiate a URL yourself
+    const url = new URL(request.url)
+ 
+    if (url.pathname.includes('/assets/')) {
+      return
+    }
+    print.warning()
+  },
+})
+```
+
 ### Response resolver arguments
 
 Response resolver function no longer accepts `req`, `res`, and `ctx` arguments. Instead, it accepts a single argument which is an object containing information about the intercepted request.


### PR DESCRIPTION
This PR introduces a small patch to the 1.x -> 2.0 migration docs referring the `onUnhandledRequest` method, which had breaking changes.

There are likely more breaking changes, but I don't know them and maybe they're not as common as the `request.url` change.

Before:
https://github.com/mswjs/msw/blob/v0.39.1/src/handlers/RequestHandler.ts#L33

After:
https://github.com/mswjs/msw/blob/d97a528914df6a656dfe7b1f63985c85845df533/src/core/utils/request/onUnhandledRequest.ts#L21C12-L21C19