### PR TITLE
fix: added missing `controller` parameter

### DIFF
--- a/websites/mswjs.io/src/content/docs/api/delay.mdx
+++ b/websites/mswjs.io/src/content/docs/api/delay.mdx
@@ -74,7 +74,7 @@ import { http, delay, HttpResponse } from 'msw'
 export const handlers = [
   http.get('/video', () => {
     const stream = new ReadableStream({
-      async start() {
+      async start(controller) {
         controller.enqueue(new Uint8Array([1, 2, 3]))
         await delay(1000)
 


### PR DESCRIPTION
Added missing `controller` parameter to the example of controlling precise delay timing when mocking response streams.