### PR TITLE
add "Managing the worker" best practice

### DIFF
--- a/websites/mswjs.io/src/content/docs/best-practices/index.mdx
+++ b/websites/mswjs.io/src/content/docs/best-practices/index.mdx
@@ -41,4 +41,10 @@ import { CommandLineIcon } from '@heroicons/react/24/outline'
     title="Dynamic mock scenarios"
     description="Apply different network scenarios on runtime."
   />
+  <PageCard
+    icon={CommandLineIcon}
+    url="/docs/best-practices/managing-the-worker"
+    title="Managing the worker"
+    description="Learn how to manage the worker script updates."
+  />
 </div>

--- a/websites/mswjs.io/src/content/docs/best-practices/managing-the-worker.mdx
+++ b/websites/mswjs.io/src/content/docs/best-practices/managing-the-worker.mdx
@@ -1,0 +1,90 @@
+---
+title: Managing the worker
+---
+
+In the browser, MSW registers a Service Worker script (`mockServiceWorker.js`) that allows it to intercept the outgoing network traffic of your application. Below, learn about the best practices of generating, verifying, and updating the worker script.
+
+## Generating the worker script
+
+To generate the worker script, run the following command in your project's root directory:
+
+```
+npx msw init <PUBLIC_DIR> --save
+```
+
+You'd have to replace the `<PUBLIC_DIR>` part with the actual path to your application's public directory. You can learn more about this step here:
+
+import { PageCard } from '../../../components/react/pageCard'
+import { CommandLineIcon } from '@heroicons/react/24/outline'
+
+<PageCard
+  icon={CommandLineIcon}
+  url="/docs/cli/init#--save"
+  title="`init` CLI command"
+  description="Generate the worker script at the given path."
+/>
+
+## Committing the worker script
+
+**It is recommended you commit the `mockServiceWorker.js` worker script in Git**. This way, everyone working on the project can get MSW up and running without having to run any additional commands.
+
+Alternatively, you can treat the worker script as a generated artifact. If you chose to do so, make sure to automate the [worker script generation](#generating-the-worker-script) so the script is created for everyone starting with the project.
+
+## Serving the worker script
+
+The entire point of `msw init` is to copy the worker script to your project's root directory so _it is available on runtime_. You must ensure that your application is serving the worker script correctly by opening the script's URL in the browser.
+
+For example, if you are running your application at `http://localhost:3000`, navigating to `http://localhost:3000/mockServiceWorker.js` must return the `application/javascript` content of the worker script. If it doesn't, you should repeat the [generation step](#generating-the-worker-script) or go through the browser integration from the start:
+
+import { WindowIcon } from '@heroicons/react/24/outline'
+
+<PageCard
+  icon={WindowIcon}
+  url="/docs/integrations/browser"
+  title="Browser integration"
+  description="Set up Mock Service Worker in the browser."
+/>
+
+## Updating the worker script
+
+The client-side code of MSW can pick up any worker script within the same major version. It is still recommended to keep the worker script up-to-date with the installed version of MSW. That is why we recommend using the `--save` flag with the `msw init` command.
+
+When run with the `--save` flag, the `msw init` command will save the used public path in `package.json`. Later, whenever you upgrade or downgrade the `msw` dependency, it will automatically generate the worker script at the saved path to keep you in-sync.
+
+```json {3-5}
+// package.json
+{
+  "msw": {
+    "workerDirectory": "./public"
+  }
+}
+```
+
+<PageCard
+  icon={CommandLineIcon}
+  url="/docs/cli/init#--save"
+  title="`--save` flag of the `init` command"
+  description="Save the public directory to enable automatic updates."
+/>
+
+### Multiple worker directories
+
+MSW supports an array of public directories as the value of the `msw.workerDirectory` property. This is especially handy when using MSW in multiple packages in a monorepo.
+
+```json {5-9}
+// package.json
+{
+  "name": "my-monorepo-root",
+  "msw": {
+    "workerDirectory": [
+      // Include multiple public directories.
+      "./packages/one/public",
+      "./packages/two/static"
+    ]
+  }
+}
+```
+
+Anytime you run `msw init` with the `--save` flag and a public directory not previously stored in `msw.workerDirectory`, MSW will automatically save the new public directory in your `package.json`.
+
+> If you decide to manually edit `msw.workerDirectory`, make sure that it's set in <em>your project's root-level `package.json`</em>.

--- a/websites/mswjs.io/src/content/docs/cli/init.mdx
+++ b/websites/mswjs.io/src/content/docs/cli/init.mdx
@@ -40,7 +40,8 @@ npx msw init ./public --save
 
 Running this command will save the `./public` directory in your `package.json`:
 
-```json {3-5}
+```json {4-6}
+// package.json
 {
   "name": "my-app",
   "msw": {
@@ -50,3 +51,15 @@ Running this command will save the `./public` directory in your `package.json`:
 ```
 
 If this property is present, whenever you install the `msw` package, the worker script will be copied to the `msw.workerDirectory` destination automatically. This ensures the worker script being in sync with the currently installed version of the library.
+
+## Related materials
+
+import { PageCard } from '../../../components/react/pageCard'
+import { CommandLineIcon } from '@heroicons/react/24/outline'
+
+<PageCard
+  icon={CommandLineIcon}
+  url="/docs/best-practices/managing-the-worker"
+  title="Managing the worker"
+  description="Learn how to manage the worker script updates."
+/>

--- a/websites/mswjs.io/src/content/docs/integrations/browser.mdx
+++ b/websites/mswjs.io/src/content/docs/integrations/browser.mdx
@@ -21,17 +21,28 @@ import { Info } from '../../../components/react/info'
   local HTTPS development, see [this recipe](/docs/recipes/using-local-https).
 </Info>
 
-## Copy the worker script
+## Generating the worker script
 
 If your application registers a Service Worker it must **host and serve it**. The library CLI provides you with the `init` command to quickly copy the `./mockServiceWorker.js` worker script into your application's public directory.
 
 ```sh
-npx msw init <PUBLIC_DIR>
+npx msw init <PUBLIC_DIR> --save
 ```
 
 > Learn more about the [`init` CLI command](/docs/cli/init).
 
 Once copied, navigate to the `/mockServiceWorker.js` URL of your application in your browser (e.g. if your application is running on `http://localhost:3000`, go to the `http://localhost:3000/mockServiceWorker.js` route). You should see the worker script contents. If you see a 404 or a MIME type error, make sure you are specifying the correct `PUBLIC_DIR` when running the `init` command, and that you adjust any potential configuration of your application that would affect serving static files.
+
+> Learn more about managing the worker script while using the library:
+
+import { CommandLineIcon } from '@heroicons/react/24/outline'
+
+<PageCard
+  icon={CommandLineIcon}
+  url="/docs/best-practices/managing-the-worker"
+  title="Managing the worker"
+  description="Learn how to manage the worker script updates."
+/>
 
 ## Setup
 


### PR DESCRIPTION
- Mention that we support multiple `msw.workerDirectory` values.
- Cross-reference browser integration, managing the worker, and the CLI command. 