### PR TITLE
revert v1 docs banner

### DIFF
--- a/websites/mswjs.io/src/components/DocsV1Banner.astro
+++ b/websites/mswjs.io/src/components/DocsV1Banner.astro
@@ -1,0 +1,7 @@
+---
+import PageBanner from "@mswjs/shared/components/PageBanner.astro";
+---
+
+<PageBanner slot="banner">
+  <p>You are viewing the docs for <strong>MSW 2.0</strong>. To access the 1.x docs <a href="https://v1.mswjs.io/" class="text-primary hover:underline" target="_blank" rel="noopener noreferrer">click here</a>.</p>
+</PageBanner>

--- a/websites/mswjs.io/src/layouts/BaseLayout.astro
+++ b/websites/mswjs.io/src/layouts/BaseLayout.astro
@@ -20,6 +20,10 @@ const { compact, ...layoutProps } = Astro.props
   keywords={['mock', 'api', 'msw', 'service', 'worker']}
   {...layoutProps}
 >
+  <Fragment slot="banner">
+    <slot name="banner" />
+  </Fragment>
+
   <Fragment slot="header">
     <Header compact={compact} />
   </Fragment>

--- a/websites/mswjs.io/src/pages/docs/[...slug].astro
+++ b/websites/mswjs.io/src/pages/docs/[...slug].astro
@@ -5,6 +5,7 @@ import type { DocsFrontmatter } from '@mswjs/shared/collections/docs'
 
 import BaseLayout from '../../layouts/BaseLayout.astro'
 import { buildDocsNavTree } from '../../content/buildDocsNavTree'
+import DocsV1Banner from '../../components/DocsV1Banner.astro'
 
 export async function getStaticPaths() {
   const docs = await getCollection('docs')
@@ -28,6 +29,8 @@ const navTree = buildDocsNavTree(allPages)
   keywords={page.data.keywords}
   compact={true}
 >
+  <DocsV1Banner slot="banner" />
+
   <DocsPageLayout
     page={page}
     navTree={navTree}

--- a/websites/mswjs.io/src/pages/docs/index.astro
+++ b/websites/mswjs.io/src/pages/docs/index.astro
@@ -4,6 +4,7 @@ import { type DocsFrontmatter } from '@mswjs/shared/collections/docs'
 import DocsPageLayout from '@mswjs/shared/layouts/DocsPageLayout.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { buildDocsNavTree } from '../../content/buildDocsNavTree'
+import DocsV1Banner from '../../components/DocsV1Banner.astro';
 
 const collection = await getCollection('docs')
 const page = collection.find((page) => {
@@ -20,6 +21,8 @@ const navTree = buildDocsNavTree(allPages)
   keywords={page.data.keywords}
   compact={true}
 >
+  <DocsV1Banner slot="banner" />
+
   <DocsPageLayout
     page={page}
     navTree={navTree}


### PR DESCRIPTION
While working on #397, I seem to have lost the v1 docs banner. This re-adds it. 