### PR TITLE
fix: Edit this page on GitHub links on mswjs.io

### DIFF
--- a/websites/mswjs.io/astro.config.mjs
+++ b/websites/mswjs.io/astro.config.mjs
@@ -9,6 +9,9 @@ import rehypePrettyCode from 'rehype-pretty-code'
 import rehypeAutolinkHeadings from 'rehype-autolink-headings'
 import rehypeExternalLinks from 'rehype-external-links'
 import { remarkLastModifiedPlugin } from '@mswjs/shared/plugins/remarkLastModifiedPlugin.ts'
+import { remarkGitHubEditUrlPlugin } from '@mswjs/shared/plugins/remarkGItHubEditUrlPlugin'
+
+import { repository } from './package.json'
 
 /** @type {import('rehype-autolink-headings').Options} */
 const autoLinkHeadingsOptions = {
@@ -34,7 +37,15 @@ export default defineConfig({
   ],
   markdown: {
     syntaxHighlight: false,
-    remarkPlugins: [remarkLastModifiedPlugin],
+    remarkPlugins: [
+      remarkLastModifiedPlugin,
+      [
+        remarkGitHubEditUrlPlugin,
+        {
+          repositoryUrl: repository.url,
+        },
+      ],
+    ],
     rehypePlugins: [
       rehypeHeadingIds,
       [rehypeExternalLinks, externalLinksOptions],

--- a/websites/mswjs.io/package.json
+++ b/websites/mswjs.io/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mswjs/mswjs.io/tree/main/websites/mswjs.io"
+    "url": "https://github.com/mswjs/mswjs.io/tree/main/websites/mswjs.io/"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^3.2.0",


### PR DESCRIPTION
I noticed that `Edit this page on GitHub` links were broken when I was about to suggest a small update to a link on the [`resetHandlers` page](https://mswjs.io/docs/api/setup-server/reset-handlers/) (will open a separate PR).

Since this was recently refactored it was easy to see what was missing here - and the `repository.url` also needed a trailing `/` :)