### PR TITLE
docs: adding readable stream object on jest setup

### DIFF
--- a/websites/mswjs.io/src/content/docs/faq.mdx
+++ b/websites/mswjs.io/src/content/docs/faq.mdx
@@ -60,7 +60,7 @@ This error means that the version of Node.js you're using doesn't support the gl
 
 Resolve this by upgrading to Node.js version 18 or higher. MSW does not support Node.js versions below version 18.
 
-## `Request`/`Response`/`TextEncoder` is not defined (Jest)
+## `Request`/`Response`/`TextEncoder`/`ReadableStream` is not defined (Jest)
 
 import JestMissingGlobals from './shared/jest-missing-globals.mdx'
 

--- a/websites/mswjs.io/src/content/docs/shared/jest-missing-globals.mdx
+++ b/websites/mswjs.io/src/content/docs/shared/jest-missing-globals.mdx
@@ -25,10 +25,12 @@ Create a `jest.polyfills.js` file next to your `jest.config.js` with the followi
  */
 
 const { TextDecoder, TextEncoder } = require('node:util')
+const { ReadableStream } = require('node:stream/web');
 
 Object.defineProperties(globalThis, {
   TextDecoder: { value: TextDecoder },
   TextEncoder: { value: TextEncoder },
+  ReadableStream: { value: ReadableStream },
 })
 
 const { Blob, File } = require('node:buffer')


### PR DESCRIPTION
Hello!

With the new version of "undici": "6.19.8", I faced a new issue with the `jest.polyfills.js`: `ReferenceError: ReadableStream is not defined`.

To fix this issue you need to add in your `jest.polyfills.js` file: ` ReadableStream: { value: ReadableStream }`.