### PR TITLE
Remove invalid warning in keeping-mocks-in-sync.mdx

### DIFF
--- a/websites/mswjs.io/src/content/docs/recipes/keeping-mocks-in-sync.mdx
+++ b/websites/mswjs.io/src/content/docs/recipes/keeping-mocks-in-sync.mdx
@@ -37,11 +37,6 @@ export const worker = setupWorker()
 setRequestHandlersByWebarchive(worker, snapshot)
 ```
 
-import { Warning } from '@mswjs/shared/components/react/warning'
-
-<Warning>
-  The `msw-webarchive` package currently doesn't support Node.js.
-</Warning>
 
 ## Automate the process
 


### PR DESCRIPTION
This warning appears to make no sense. It seems that https://github.com/Tapico/tapico-msw-webarchive *only* supports Nodejs, so the warning is misleading.