### PR TITLE
fix: replace printHandlers with listHandlers in setupWorker

### DIFF
--- a/websites/mswjs.io/src/content/docs/api/setup-worker/index.mdx
+++ b/websites/mswjs.io/src/content/docs/api/setup-worker/index.mdx
@@ -47,4 +47,5 @@ The `setupWorker()` function returns you a _worker instance_ that is an object y
 - [`use(...handlers)`](/docs/api/setup-worker/use)
 - [`resetHandlers(...handlers)`](/docs/api/setup-worker/reset-handlers)
 - [`restoreHandlers()`](/docs/api/setup-worker/restore-handlers)
-- [`printHandlers()`](/docs/api/setup-worker/print-handlers)
+- [`listHandlers()`](/docs/api/setup-worker/list-handlers)
+  - The `.printHandlers()` method on `worker`/`server` has been removed in favor of the new `.listHandlers()` method.


### PR DESCRIPTION
Updated the setupWorker documentation to replace the `printHandlers` link with `listHandlers`, as it already redirects to `listHandlers`. Added a note to indicate that `printHandlers` has been removed.

ref. #332 