### PR TITLE
fix: missing 'server' in client-to-server forwarding example

### DIFF
--- a/websites/mswjs.io/src/content/docs/basics/handling-websocket-events.mdx
+++ b/websites/mswjs.io/src/content/docs/basics/handling-websocket-events.mdx
@@ -216,7 +216,7 @@ chat.addEventListener('connection', ({ server }) => {
 Once the server connection has been established, all outgoing client message events are forwarded to the server. To prevent this behavior, call `event.preventDefault()` on the client message event. You can use this to modify the client-sent data before it reaches the server or ignore it completely.
 
 ```js
-chat.addEventListener('connection', ({ client }) => {
+chat.addEventListener('connection', ({ client, server }) => {
   client.addEventListener('message', (event) => {
     // Prevent the default client-to-server forwarding.
     event.preventDefault()


### PR DESCRIPTION
This PR fixes a missing server reference in the Client-to-server forwarding example. The original example does not define where server comes from, which may cause confusion. The fix updates the connection event handler to destructure both client and server properly.

### Changes
Updated the event listener to include `{ client, server }` instead of just `{ client }`.

### Before

```js
chat.addEventListener('connection', ({ client }) => {
  client.addEventListener('message', (event) => {
    event.preventDefault()
    server.send(event.data + 'mocked')
  })
})
```

### After

```js
chat.addEventListener('connection', ({ client, server }) => {
  client.addEventListener('message', (event) => {
    event.preventDefault()
    server.send(event.data + 'mocked')
  })
})
```

Let me know if you want any adjustments! 🚀