### PR TITLE
fix font rendering for Safari

### DIFF
--- a/websites/mswjs.io/public/fonts/inter/inter.css
+++ b/websites/mswjs.io/public/fonts/inter/inter.css
@@ -3,4 +3,5 @@
   font-family: Inter;
   font-style: normal;
   font-display: swap;
+  font-weight: 100 900;
 }


### PR DESCRIPTION
## What

Safari was not able to properly render fonts that had a different font weight than `400`.  This is now fixed, and Safari can render the Inter font the same as the other browser.

## Why this happened

Safari needs an explicit mapping for which font weight belong to which file. The solution was to widen the font-face rule for the variable font so it includes all font weights from 100 to 900.

## Screenshots

I've added some before and after pictures. Left is before and right is after.

<img width="1398" alt="Bildschirmfoto 2025-04-18 um 10 58 56" src="https://github.com/user-attachments/assets/30555643-f3fc-43e8-b8a1-150c8abfaf78" />
<img width="176" alt="Bildschirmfoto 2025-04-18 um 10 59 14" src="https://github.com/user-attachments/assets/0590da6e-7c1c-4b9c-9532-da0a7090f002" />
<img width="176" alt="Bildschirmfoto 2025-04-18 um 10 59 18" src="https://github.com/user-attachments/assets/7aa8b955-d3ba-4d57-9220-88bc59affca0" />

<br />
<img width="256" alt="Bildschirmfoto 2025-04-18 um 10 59 27" src="https://github.com/user-attachments/assets/904e0b35-2800-429d-8459-d57633c3c19d" />
<img width="256" alt="Bildschirmfoto 2025-04-18 um 10 59 30" src="https://github.com/user-attachments/assets/e355bb4a-9672-4504-ae20-3a6803f75081" />



