### PR TITLE
fix: footer dead link

### DIFF
--- a/websites/shared/components/SocialLinksList.astro
+++ b/websites/shared/components/SocialLinksList.astro
@@ -47,7 +47,7 @@ const props = Astro.props
   </li>
   <li>
     <a
-      href="https://kettanaito.com/discords"
+      href="https://kettanaito.com/discord"
       arial-label="Discord server"
       class="flex p-2 hover:text-white"
       target="_blank"


### PR DESCRIPTION
The footer Discord link redirects to an incorrect page.

![image](https://github.com/user-attachments/assets/ad8f6e35-6d13-4d8d-9ccb-380664811c3b)

This PR fixes the typo, redirects to `https://kettanaito.com/discord`

