### PR TITLE
fix unwrapped bypass function in response-patching.mdx

### DIFF
--- a/websites/mswjs.io/src/content/docs/http/mocking-responses/response-patching.mdx
+++ b/websites/mswjs.io/src/content/docs/http/mocking-responses/response-patching.mdx
@@ -18,7 +18,7 @@ import { http, HttpResponse, bypass } from 'msw'
 
 http.get('/resource', async ({ request }) => {
   // Get the original JSON response from the server.
-  const originalData = await bypass(request).then((response) => response.json())
+  const originalData = await fetch(bypass(request)).then((response) => response.json())
 
   return HttpResponse.json({
     // Combine the original data with the mocked data.


### PR DESCRIPTION
This fixes the code snippet in the response-patching page by matching the usage of `bypass` found elsewhere https://mswjs.io/docs/api/bypass/