### PR TITLE
Update index.mdx - fixed typo

### DIFF
--- a/websites/source.mswjs.io/src/content/docs/index.mdx
+++ b/websites/source.mswjs.io/src/content/docs/index.mdx
@@ -15,7 +15,7 @@ Source is a library for generating request handlers for [Mock Service Worker](ht
 
 Source is designed to breach that gap and allow you to generate request handlers from supported inputs, like OpenAPI documents or HAR files.
 
-I was inspired to create Source by a particular development workflow. Imagine you have finally reproduced a network-related issue in your browser, and now your job is to write a regression test for it. Refresh the page—and the reproduction is gone. So, instead, you should be able to save the network inro an `*.har` file, put it next to your test suite, and use Source to generate request handlers out of it and achieve reliable, reproducible network behavior to replay the issue on demand.
+I was inspired to create Source by a particular development workflow. Imagine you have finally reproduced a network-related issue in your browser, and now your job is to write a regression test for it. Refresh the page—and the reproduction is gone. So, instead, you should be able to save the network info as an `*.har` file, put it next to your test suite, and use Source to generate request handlers out of it and achieve reliable, reproducible network behavior to replay the issue on demand.
 
 That is precisely what Source enables you to do!
 


### PR DESCRIPTION
Fixed typo: `network inro`