### PR TITLE
Fix broken Page Card links on `/docs/runbook` page

### DIFF
--- a/websites/mswjs.io/src/content/docs/runbook.mdx
+++ b/websites/mswjs.io/src/content/docs/runbook.mdx
@@ -100,7 +100,7 @@ import { NewspaperIcon } from '@heroicons/react/24/outline'
 
 <PageCard
   icon={NewspaperIcon}
-  url="/docs/basics/intercepting-requests"
+  url="/docs/http/intercepting-requests/"
   title="Intercepting requests"
   description="Learn about request interception and how to capture REST and GraphQL requests."
 />
@@ -128,7 +128,7 @@ If unsure, please read about mocking responses with MSW:
 
 <PageCard
   icon={NewspaperIcon}
-  url="/docs/basics/mocking-responses"
+  url="/docs/http/mocking-responses"
   title="Mocking responses"
   description="Learn about response resolvers and the different ways to respond to a request."
 />


### PR DESCRIPTION
For both Intercepting Requests and Mocking Responses Page Card components, the URLs for these incorrectly referenced `/docs/basics/` when they are now `/docs/http/`