### PR TITLE
docs: update avoid-request-assertions.mdx

### DIFF
--- a/websites/mswjs.io/src/content/docs/best-practices/avoid-request-assertions.mdx
+++ b/websites/mswjs.io/src/content/docs/best-practices/avoid-request-assertions.mdx
@@ -66,4 +66,4 @@ This is particularly useful option to set in your test setup file.
 
 That being said, there are scenarios when a performed request has no indication in the application that can be asserted. These are usually one-way requests against third-party services, like analytics or monitoring.
 
-For those cases, please use the [Life-cycle events API](/docs/api/life-cycle-events) to provide direct assertions on requests/responses.
+For those cases, please use the [Life-cycle events API](/docs/api/life-cycle-events) or use the [msw-request-assertion](https://www.npmjs.com/package/msw-request-assertions) package to provide direct assertions on requests/responses.


### PR DESCRIPTION
My company has a project that provides integrations with a lot of 3rd party API, those bridging code involves transformation of input and producing 3rd third-party API calls, in that case, the outgoing API call is the main/the only side effect we could test.

Those assertion are become harder to manage, so I've created a package to simplify the assertion

Link: https://github.com/marklai1998/msw-request-assertions

Dont worry, I've put a warning in the README that re-emphasize not to do request assertion except edge cases