### PR TITLE
docs: Update network-errors.mdx

### DIFF
--- a/websites/mswjs.io/src/content/docs/http/mocking-responses/network-errors.mdx
+++ b/websites/mswjs.io/src/content/docs/http/mocking-responses/network-errors.mdx
@@ -9,7 +9,7 @@ keywords:
   - ssl
 ---
 
-You can respond to the intercepted request with [`Response.error()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/error_static) that's designed to represent a network error. The `Response.error()` static method returns a special kind of `Response` insatnce that doesn't get treated as a normal server response. Instead, it results in a network error, **aborting the pending request**.
+You can respond to the intercepted request with [`Response.error()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/error_static) that's designed to represent a network error. The `Response.error()` static method returns a special kind of `Response` instance that doesn't get treated as a normal server response. Instead, it results in a network error, **aborting the pending request**.
 
 ```ts {2}
 http.get('/resource', () => {


### PR DESCRIPTION
Minor correction to the documentation in `network-errors.mdx`. The change fixes a typo in the word "instance"