### PR TITLE
Fix a typo

### DIFF
--- a/websites/mswjs.io/src/content/docs/graphql/intercepting-operations/index.mdx
+++ b/websites/mswjs.io/src/content/docs/graphql/intercepting-operations/index.mdx
@@ -10,7 +10,7 @@ This page will walk you through the possible ways to intercept a GraphQL operati
 
 ## Endpoint-first mocking
 
-By default, the library **ignores the server sendpoint** when matching GraphQL operations. That is a conscious decision since it is rare that a single application would interact with multiple GraphQL APIs. It means that the same handler will match a `GetUser` operation even if one is sent to `/api/graphql` and the other to `https://api.example.com`.
+By default, the library **ignores the servers endpoint** when matching GraphQL operations. That is a conscious decision since it is rare that a single application would interact with multiple GraphQL APIs. It means that the same handler will match a `GetUser` operation even if one is sent to `/api/graphql` and the other to `https://api.example.com`.
 
 This default is supported for backward-compatibility, but it is **strongly recommended** to use [`graphql.link()`](/docs/api/graphql#graphqllinkurl) to scope GraphQL mocking to a particular server endpoint.
 


### PR DESCRIPTION
The docs contain a typo on the "Intercepting GraphQL operations" page.