### PR TITLE
Doc: Update codemod link for MSW migration

### DIFF
--- a/websites/mswjs.io/src/content/docs/migrations/1.x-to-2.x.mdx
+++ b/websites/mswjs.io/src/content/docs/migrations/1.x-to-2.x.mdx
@@ -25,7 +25,7 @@ import { NewspaperIcon } from '@heroicons/react/24/solid'
 
 Our friends at Codemod.com have prepared a fantastic **collection of codemods** that can help you migrate to MSW 2.0.
 
-- [**Codemods to migrate**](https://codemod.com/automations/msw-2-upgrade-recipe/)
+- [**Codemods to migrate**](https://go.codemod.com/msw-codemods)
 
 ## Installation
 


### PR DESCRIPTION
Update codemod link for MSW migration.

Note: `npx codemod@latest msw-2-upgrade-recipe` is the latest MSW codemod. 

(users are discouraged to use the legacy one: `npx codemod@latest msw/2/upgrade-recipe`)
