### PR TITLE
docs: Update custom-worker-script-location.mdx

### DIFF
--- a/websites/mswjs.io/src/content/docs/recipes/custom-worker-script-location.mdx
+++ b/websites/mswjs.io/src/content/docs/recipes/custom-worker-script-location.mdx
@@ -12,6 +12,10 @@ await worker.start({
     // This is useful if your application follows
     // a strict directory structure.
     url: '/assets/mockServiceWorker.js',
+    options: {
+      // Required if you opt-in to Service-Worker-Allowed header
+      scope: "YOUR_TARGET_SCOPE",
+    },
   },
 })
 ```


### PR DESCRIPTION
# problem

I was getting errors and warnings despite setting the Service-Worker-Allowed header.


# solution

clarify that you MUST tell MSW about the scope!