### PR TITLE
docs: Update import paths from .js to .ts in quick-start

### DIFF
--- a/websites/mswjs.io/src/content/docs/quick-start.mdx
+++ b/websites/mswjs.io/src/content/docs/quick-start.mdx
@@ -44,7 +44,7 @@ Since Vitest tests run in a Node.js process, let's use `setupServer` from `msw/n
 ```ts /setupServer/1,2 /handlers/1,3#v
 // src/mocks/node.ts
 import { setupServer } from 'msw/node'
-import { handlers } from './handlers.js'
+import { handlers } from './handlers.ts'
 
 export const server = setupServer(...handlers)
 ```
@@ -58,7 +58,7 @@ At this step, you find the appropriate place to enable API mocking in your Node.
 ```ts /server/
 // vitest.setup.ts
 import { beforeAll, afterEach, afterAll } from 'vitest'
-import { server } from './mocks/node.js'
+import { server } from './mocks/node.ts'
 
 beforeAll(() => server.listen())
 afterEach(() => server.resetHandlers())


### PR DESCRIPTION
The [3rd](https://mswjs.io/docs/quick-start#3-process-level-integration) and [4th](https://mswjs.io/docs/quick-start#4-tool-level-integration) steps example at the quick start uses the wrong file extension(js) instead of ts
<img width="2560" height="1415" alt="image" src="https://github.com/user-attachments/assets/002eb680-1514-4fe6-911a-e51a09add1b9" />
<img width="2560" height="1415" alt="image" src="https://github.com/user-attachments/assets/23742de0-09b0-4617-a009-18defddcf17d" />
