### PR TITLE
Fix typo in WebSocket docs

### DIFF
--- a/websites/mswjs.io/src/content/docs/websocket/server-events/index.mdx
+++ b/websites/mswjs.io/src/content/docs/websocket/server-events/index.mdx
@@ -42,7 +42,7 @@ api.addEventListener('connection', ({ server }) => {
 })
 ```
 
-### The `message event
+### The `message` event
 
 ```ts {3-5}
 api.addEventListener('connection', ({ server }) => {


### PR DESCRIPTION
fix typo in [docs](https://mswjs.io/docs/websocket/server-events/#the-message-event)

- Before
  <img width="1076" height="257" alt="image" src="https://github.com/user-attachments/assets/f01260cd-9820-4ad6-94f4-0585b7cc458a" />
- After
  <img width="1084" height="262" alt="image" src="https://github.com/user-attachments/assets/13885120-458e-4856-a362-156bb9730e1e" />
