### PR TITLE
docs(typescript): fix RequestBodyType and ResponseBodyType descriptions

### DIFF
--- a/websites/mswjs.io/src/content/docs/best-practices/typescript.mdx
+++ b/websites/mswjs.io/src/content/docs/best-practices/typescript.mdx
@@ -28,8 +28,8 @@ http.get<Params, RequestBodyType, ResponseBodyType, Path>(path, resolver)
 | Argument name      | Type     | Description                                                                                              |
 | ------------------ | -------- | -------------------------------------------------------------------------------------------------------- |
 | `Params`           | `object` | Request path parameters. Narrows the `params` response resolver argument type.                           |
-| `RequestBodyType`  | `object` | Request path parameters. Narrows the `request.json()` return type.                                       |
-| `ResponseBodyType` | `object` | Request path parameters. Narrows the `HttpResponse.text()` and `HttpResponse.json()` response body type. |
+| `RequestBodyType`  | `object` | Request body type. Narrows the `request.json()` return type.                                             |
+| `ResponseBodyType` | `object` | Response body type. Narrows the `HttpResponse.text()` and `HttpResponse.json()` response body type.      |
 | `Path`             | `string` | Request path. Narrows the `path` argument on the request handler.                                        |
 
 ```ts


### PR DESCRIPTION
## Summary
- fix the generic argument table in the TypeScript best-practices docs
- update `RequestBodyType` description to say "Request body type"
- update `ResponseBodyType` description to say "Response body type"

## Context
This addresses the typo reported in mswjs/msw#2664.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter mswjs.io build` (verified in a no-space path clone due local workspace path containing a trailing space)
