### PR TITLE
Revise mocking setup instructions for React Native

### DIFF
--- a/websites/mswjs.io/src/content/docs/integrations/react-native.mdx
+++ b/websites/mswjs.io/src/content/docs/integrations/react-native.mdx
@@ -65,14 +65,10 @@ export const server = setupServer(...handlers)
 
 ### Development
 
-Import `server` in the entrypoint of your React Native application and call `server.listen()` _conditionally_.
+Import `server` at the top of your React Native application, call `server.listen()` _conditionally_, and wait for MSW to initialize before rendering your app component.
 
 ```js {6-14} /enableMocking/
-// index.js
-import { AppRegistry } from 'react-native'
-import App from './src/App'
-import { name as appName } from './app.json'
-
+// App.tsx
 async function enableMocking() {
   if (!__DEV__) {
     return
@@ -83,9 +79,27 @@ async function enableMocking() {
   server.listen()
 }
 
-enableMocking().then(() => {
-  AppRegistry.registerComponent(appName, () => App)
-})
+export function App() {
+  const [isMockingReady, setIsMockingReady] = useState(!__DEV__);
+
+  useEffect(() => {
+    if (!__DEV__) return
+
+    async function enableMocking() {
+      // @ts-ignore
+      await import("../msw.polyfills")
+      const { server } = await import("./mocks/server")
+      server.listen()
+      setIsMockingReady(true)
+    }
+
+    enableMocking()
+  }, [])
+
+  if (!isMockingReady) return null
+
+  return <View>{...}</View>
+}
 ```
 
 > Don't forget to import the `msw.polyfills.js` module!

--- a/websites/mswjs.io/src/content/docs/integrations/react-native.mdx
+++ b/websites/mswjs.io/src/content/docs/integrations/react-native.mdx
@@ -86,7 +86,6 @@ export function App() {
     if (!__DEV__) return
 
     async function enableMocking() {
-      // @ts-ignore
       await import("../msw.polyfills")
       const { server } = await import("./mocks/server")
       server.listen()

--- a/websites/mswjs.io/src/content/docs/integrations/react-native.mdx
+++ b/websites/mswjs.io/src/content/docs/integrations/react-native.mdx
@@ -37,21 +37,42 @@ Create a new `msw.polyfills.js` file with the following content:
 // msw.polyfills.js
 import 'fast-text-encoding'
 import 'react-native-url-polyfill/auto'
+import "web-streams-polyfill/dist/polyfill"
+
+if (typeof globalThis.MessageEvent === "undefined") {
+  globalThis.MessageEvent = class MessageEvent {
+    constructor(type, init) {
+      this.type = type
+      this.data = init?.data ?? null
+      this.origin = init?.origin ?? ""
+      this.lastEventId = init?.lastEventId ?? ""
+      this.source = init?.source ?? null
+      this.ports = init?.ports ?? []
+    }
+  }
+}
+
+if (typeof globalThis.BroadcastChannel === "undefined") {
+  globalThis.BroadcastChannel = class BroadcastChannel {
+    constructor(_name) {}
+    postMessage() {}
+    close() {}
+    addEventListener() {}
+    removeEventListener() {}
+    dispatchEvent() {
+      return true
+    }
+  }
+}
 ```
 
 We will import this file later, when [Enabling mocking](#enable-mocking).
 
-## Setup
+## Enable mocking
 
-Import the `setupServer` function from `msw/native` and call it, providing your request handlers as the argument.
+### Development
 
-```js {2}
-// src/mocks/server.js
-import { setupServer } from 'msw/native'
-import { handlers } from './handlers'
-
-export const server = setupServer(...handlers)
-```
+Import the `setupServer` function from `msw/native` and call it _conditionally_, providing your request handlers as the argument
 
 > Learn more about the [`setupServer` API](/docs/api/setup-server). It's the same for Node.js and React Native.
 
@@ -61,48 +82,24 @@ export const server = setupServer(...handlers)
   environment.
 </Warning>
 
-## Enable mocking
-
-### Development
-
-Import `server` at the top of your React Native application, call `server.listen()` _conditionally_, and wait for MSW to initialize before rendering your app component.
-
 ```js {6-14} /enableMocking/
-// App.tsx
-async function enableMocking() {
-  if (!__DEV__) {
-    return
-  }
+// index.js
+import { AppRegistry } from 'react-native'
+import App from './src/App'
+import { name as appName } from './app.json'
 
-  await import('./msw.polyfills')
-  const { server } = await import('./src/mocks/server')
+async function enableMocking() {
+  if (!__DEV__) return
+
+  require("./msw.polyfills")
+  const { setupServer } = require("msw/native")
+  const { handlers } = require("./app/mocks/handlers")
+  const server = setupServer(...handlers)
   server.listen()
 }
 
-export function App() {
-  // In production builds, this will start `true` and we skip flipping it in the `useEffect`
-  const [isMockingReady, setIsMockingReady] = useState(!__DEV__);
-
-  useEffect(() => {
-    if (!__DEV__) return
-
-    async function enableMocking() {
-      await import("./msw.polyfills")
-      const { server } = await import("./mocks/server")
-      server.listen()
-      setIsMockingReady(true)
-    }
-
-    enableMocking()
-  }, [])
-
-  if (!isMockingReady) return null
-
-  return <View>{...}</View>
-}
+enableMocking().then(() => registerRootComponent(App))
 ```
-
-> Don't forget to import the `msw.polyfills.js` module!
 
 ### Testing
 

--- a/websites/mswjs.io/src/content/docs/integrations/react-native.mdx
+++ b/websites/mswjs.io/src/content/docs/integrations/react-native.mdx
@@ -80,6 +80,7 @@ async function enableMocking() {
 }
 
 export function App() {
+  // In production builds, this will start `true` and we skip flipping it in the `useEffect`
   const [isMockingReady, setIsMockingReady] = useState(!__DEV__);
 
   useEffect(() => {

--- a/websites/mswjs.io/src/content/docs/integrations/react-native.mdx
+++ b/websites/mswjs.io/src/content/docs/integrations/react-native.mdx
@@ -86,7 +86,7 @@ export function App() {
     if (!__DEV__) return
 
     async function enableMocking() {
-      await import("../msw.polyfills")
+      await import("./msw.polyfills")
       const { server } = await import("./mocks/server")
       server.listen()
       setIsMockingReady(true)


### PR DESCRIPTION
Hey folks - love MSW. I recently used it on a large React Native project to some success and I'm trying to document some of the pain points of React Native integration (see this example PR integrating with Ignite: https://github.com/infinitered/mswtest/pull/2).

I'm not exactly sure what the mechanism is, but if you `await` anything before calling `registerRootComponent`, Expo will fail to register the app entry. [I have a demo of the issue here](https://github.com/infinitered/mswtest/pull/2#:~:text=Do%20not%20register%20root%20component%20after%20a%20delay)


I propose using some check at the top of the app tree, although another good approach might be to [delay hiding the splash screen](https://docs.expo.dev/versions/latest/sdk/splash-screen/#delay-hiding-the-splash-screen)