### PR TITLE
docs: Update example to reset handlers before tests

### DIFF
--- a/websites/mswjs.io/src/content/docs/recipes/vitest-browser-mode.mdx
+++ b/websites/mswjs.io/src/content/docs/recipes/vitest-browser-mode.mdx
@@ -32,12 +32,13 @@ export const test = testBase.extend({
       // Start the worker before the test.
       await worker.start()
 
-      // Expose the worker object on the test's context.
-      await use(worker)
-
       // Remove any request handlers added in individual test cases.
       // This prevents them from affecting unrelated tests.
+      // Doing so before each test to match other clenups and enabling screenshots after each test run
       worker.resetHandlers()
+
+      // Expose the worker object on the test's context.
+      await use(worker)
     },
     {
       auto: true,


### PR DESCRIPTION
Updating the example setup to match defaults of libraries like [vitest-browser-react](https://github.com/vitest-community/vitest-browser-react) where cleanup is done before each test instead of after to allow screenshots